### PR TITLE
[SETI-944] Use GITLEAKS_ secrets in secret-scan workflows

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Secrets Scan
         uses: Typeform/.github/shared-actions/secrets-scan@master
         with:
-          docker-registry: ${{ secrets.DOCKER_REGISTRY }}
-          docker-username: ${{ secrets.DOCKER_USERNAME }}
-          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-registry: ${{ secrets.GITLEAKS_DOCKER_REGISTRY }}
+          docker-username: ${{ secrets.GITLEAKS_DOCKER_USERNAME }}
+          docker-password: ${{ secrets.GITLEAKS_DOCKER_PASSWORD }}
           gh-token: ${{ secrets.GH_TOKEN }}

--- a/workflow-templates/secrets-scan.yml
+++ b/workflow-templates/secrets-scan.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Secrets Scan
         uses: Typeform/.github/shared-actions/secrets-scan@master
         with:
-          docker-registry: ${{ secrets.DOCKER_REGISTRY }}
-          docker-username: ${{ secrets.DOCKER_USERNAME }}
-          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-registry: ${{ secrets.GITLEAKS_DOCKER_REGISTRY }}
+          docker-username: ${{ secrets.GITLEAKS_DOCKER_USERNAME }}
+          docker-password: ${{ secrets.GITLEAKS_DOCKER_PASSWORD }}
           gh-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
We introduced new secrets that are also available for public repos. We
should use those in the Secrets Scan workflows so that it works with
all repos and not only with private ones.