### PR TITLE
fix: exiting secrets scan script with gitleaks outcome

### DIFF
--- a/shared-actions/secrets-scan/secrets-scan.sh
+++ b/shared-actions/secrets-scan/secrets-scan.sh
@@ -82,3 +82,5 @@ fi
 
 # Clean up
 docker logout
+
+exit $exit_code


### PR DESCRIPTION
The `secrets-scan.sh` script was not returning the actual exit code from `gitleaks` execution. Now it does.