### PR TITLE
chore(fear-726): add PR hook for github action

### DIFF
--- a/workflow-templates/library-checks-and-release.yml
+++ b/workflow-templates/library-checks-and-release.yml
@@ -7,7 +7,13 @@ on:
       - next
       - alpha
       - beta
-
+  pull_request:
+    branches:
+      - master
+      - next
+      - alpha
+      - beta
+   
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
Add PR hook for github action

Note that:
* so, it does all the commands for pushes against the “release” branches (master/next/etc.) and for pushes to branches having PR opened against those branches

* the trick is that the `yarn semantic-release` will only happen for push against release branches (by default, refer to [doc](https://semantic-release.gitbook.io/semantic-release/usage/configuration))

![image](https://user-images.githubusercontent.com/6507291/111192944-eb6a7a80-85b9-11eb-8e06-a6d482968d85.png)
