### PR TITLE
feat(fear-1031): add custom action for setting up js repos

### DIFF
--- a/shared-actions/js-ts-environment-setup/action.yml
+++ b/shared-actions/js-ts-environment-setup/action.yml
@@ -1,14 +1,16 @@
 name: JS/TS environment setup
-description: 'Set up node & npm config, Get repo and install its dependencies (using cache)'
+description: 'Set up node and npm config, and install dependencies'
 inputs:
   gh-token:
     description: 'Github Token'
     required: true
+  cache-key:
+    description: 'Key used for caching the external dependencies. If missing, the cache is not used'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v2
-
     - name: Set up Node.js
       uses: actions/setup-node@v1
       with:
@@ -20,12 +22,13 @@ runs:
         npm config set @typeform:registry https://npm.pkg.github.com/
 
     - name: Get yarn cache
+      if: inputs.cache-key != ''
       uses: actions/cache@v2
       id: yarn-cache
       with:
         path: node_modules
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('.github/workflows/**.yml') }}
+        key: ${{ inputs.cache-key }}
 
     - name: Install Node.js dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      if: ${{ inputs.cache-key == '' || steps.yarn-cache.outputs.cache-hit != 'true' }}
       run: yarn install --frozen-lockfile

--- a/shared-actions/npm-setup/action.yml
+++ b/shared-actions/npm-setup/action.yml
@@ -1,0 +1,31 @@
+name: JS/TS environment setup
+description: 'Set up node & npm config, Get repo and install its dependencies (using cache)'
+inputs:
+  gh-token:
+    description: 'Github Token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+
+    - name: Set up registry
+      run: |
+        npm config set '//npm.pkg.github.com/:_authToken' ${{ inputs.gh-token }}
+        npm config set @typeform:registry https://npm.pkg.github.com/
+
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('.github/workflows/**.yml') }}
+
+    - name: Install Node.js dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile


### PR DESCRIPTION
In some cases, we have seen this piece of code repeated multiple times in the [same GH action file](https://github.com/Typeform/chief/blob/master/.github/workflows/checks-and-release.yml#L26-L48) and decided that it would be nice to encapsulate it in a custom action.
Apart from reducing the number of lines of code, an extra benefit would also be that, if we wanted to upgrade the node version or change the registry url, it could be done easily here, in one place. 