### PR TITLE
feat(SP-1466): adding FoD reusable workflow

### DIFF
--- a/.github/workflows/fod-sast-scan.yaml
+++ b/.github/workflows/fod-sast-scan.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   FoD-SAST-Scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, automated-checks]
 
     steps:
       - name: Check Out Source Code

--- a/.github/workflows/fod-sast-scan.yaml
+++ b/.github/workflows/fod-sast-scan.yaml
@@ -10,6 +10,9 @@ on:
       fod_release_id:
         required: true
         type: string
+      files:
+        required: true
+        type: string
     secrets:
       FOD_USER:
         required: true
@@ -36,7 +39,7 @@ jobs:
       - name: Zip source code
         uses: vimtor/action-zip@v1
         with:
-          files: cmd/ internal/ pkg/ vendor/ Makefile go.mod go.sum
+          files: ${{ inputs.files }}
           dest: source.zip
       
       # Start Fortify on Demand SAST scan

--- a/.github/workflows/fod-sast-scan.yaml
+++ b/.github/workflows/fod-sast-scan.yaml
@@ -1,0 +1,55 @@
+name: Fortify on Demand Static Application Security Testing
+
+# For every new commit made to the default branch, zip the interesting parts of the code,
+# and submit them to our Fortify on Demand instance.
+# A new Static Application Security Testing (SAST) scan will be made.
+
+on:
+  workflow_call:
+    inputs:
+      fod_release_id:
+        required: true
+        type: string
+    secrets:
+      FOD_USER:
+        required: true
+      FOD_PAT:
+        required: true
+
+jobs:
+  FoD-SAST-Scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Source Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      
+      # Java 8 required by FoD Uploader
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      
+      # Pack source code
+      - name: Zip source code
+        uses: vimtor/action-zip@v1
+        with:
+          files: cmd/ internal/ pkg/ vendor/ Makefile go.mod go.sum
+          dest: source.zip
+      
+      # Start Fortify on Demand SAST scan
+      - name: Download FoD Uploader (Fortify on Demand Universal CI Tool)
+        uses: fortify/gha-setup-fod-uploader@v1
+      - name: Perform SAST Scan
+        run: java -jar $FOD_UPLOAD_JAR -z source.zip -aurl $FOD_API_URL -purl $FOD_URL -rid "$FOD_RELEASE_ID" -tc "$FOD_TENANT" -uc "$FOD_USER" "$FOD_PAT" $FOD_UPLOADER_OPTS -n "$FOD_UPLOADER_NOTES"
+        env: 
+          FOD_TENANT: "typeform"
+          FOD_USER: ${{ secrets.FOD_USER }}
+          FOD_PAT: ${{ secrets.FOD_PAT }}
+          FOD_RELEASE_ID: ${{ inputs.fod_release_id }}
+          FOD_URL: "https://emea.fortify.com/"
+          FOD_API_URL: "https://api.emea.fortify.com/"
+          FOD_UPLOADER_OPTS: "-entitlementPreferenceType 2 -inProgressScanActionType 1" # (2) for SubscriptionOnly and (1) for CancelScanInProgress and start a scan
+          FOD_UPLOADER_NOTES: 'Triggered by GitHub Actions (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) in commit ${{ github.sha }}'

--- a/reusable-workflows/fortify-on-demand/workflow.yaml
+++ b/reusable-workflows/fortify-on-demand/workflow.yaml
@@ -1,0 +1,1 @@
+.github/workflows/fod-sast-scan.yaml


### PR DESCRIPTION
Creating a reusable workflow that zips the chosen files and directories and sends them to a Fortify on Demand instance. There, a Static Application Security Testing (SAST) test will be performed and reviewed by the Security team asynchronously.

An example usage:
```yaml
jobs:
  FoD-SAST-Scan:
    uses: Typeform/.github/.github/workflows/fod-sast-scan.yaml@v1
    with:
      fod_release_id: "12345"
      files: src/ Dockerfile Makefile package.json yarn.lock
    secrets:
      FOD_USER: ${{ secrets.FOD_USER }}
      FOD_PAT: ${{ secrets.FOD_PAT }}
```