### PR TITLE
BEAR-3367 Upgrade golangci-lint version

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         id: golangci-lint
         with:
-          version: v1.44.0
+          version: v1.44.2
           only-new-issues: true
           skip-go-installation: true
           args: --config lint-config/config/golangci.yaml --issues-exit-code=1


### PR DESCRIPTION
Upgrade golangci-lint version to v1.44.2

Related to https://github.com/Typeform/golang-builder/pull/40