### PR TITLE
docs: [EINT-1873] update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,9 @@ shared-actions/send-deployment-event                        @Typeform/engineerin
 workflow-templates/send-deployment-event.properties.json    @Typeform/engineering-intelligence
 workflow-templates/send-deployment-event.svg                @Typeform/engineering-intelligence
 workflow-templates/send-deployment-event.yml                @Typeform/engineering-intelligence
-workflow-templates/ci-standard-checks.yml                   @Typeform/engineering-intelligence
-workflow-templates/ci-standard-checks.svg                   @Typeform/engineering-intelligence
-workflow-templates/ci-standard-checks.properties.json       @Typeform/engineering-intelligence
+workflow-templates/ci-standard-checks.yml                   @Typeform/devtools
+workflow-templates/ci-standard-checks.svg                   @Typeform/devtools
+workflow-templates/ci-standard-checks.properties.json       @Typeform/devtools
 workflow-templates/frontend-canary-cleanup.yml              @Typeform/frontend-architecture
 workflow-templates/frontend-canary-cleanup.svg              @Typeform/frontend-architecture
 workflow-templates/frontend-canary-cleanup.properties.json  @Typeform/frontend-architecture


### PR DESCRIPTION
Update new owners of ci-standards-checks as it got transferred from Engineering Intelligence to DevTools Team