### PR TITLE
chore(BLOCKS-897): accept working directory input for monorepos

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -17,6 +17,10 @@ on:
         required: false
         default: true
 
+defaults:
+  run:
+    working-directory: ${{ inputs.working-directory }}
+
 jobs:
   lint:
     if: ${{ !contains('Bot', github.event.pull_request.user.type) }}

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -17,10 +17,6 @@ on:
         required: false
         default: true
 
-defaults:
-  run:
-    working-directory: ${{ inputs.working-directory }}
-
 jobs:
   lint:
     if: ${{ !contains('Bot', github.event.pull_request.user.type) }}
@@ -40,7 +36,7 @@ jobs:
         with:
           repository: Typeform/golang-builder
           ref: main
-          path: lint-config
+          path: ${{ github.workspace }}/lint-config
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Set local imports
@@ -71,7 +67,7 @@ jobs:
           only-new-issues: ${{ inputs.only-new-issues }}
           skip-go-installation: true
           working-directory: ${{ inputs.working-directory }}
-          args: --config lint-config/config/golangci.yaml --issues-exit-code=1
+          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --issues-exit-code=1
 
       - name: Comment body
         id: comment-body-content

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -45,7 +45,7 @@ jobs:
           find: "<repository>"
           replace: ${{ steps.repo-name.outputs.value }}
           regex: false
-          include: "lint-config/config/golangci.yaml"
+          include: "${{ github.workspace }}/lint-config/config/golangci.yaml"
 
       - name: Configure git for private modules
         env:

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -12,6 +12,10 @@ on:
         type: string
         required: false
         default: "."
+      only-new-issues:
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   lint:
@@ -60,7 +64,7 @@ jobs:
         id: golangci-lint
         with:
           version: v1.45.2
-          only-new-issues: true
+          only-new-issues: ${{ inputs.only-new-issues }}
           skip-go-installation: true
           working-directory: ${{ inputs.working-directory }}
           args: --config lint-config/config/golangci.yaml --issues-exit-code=1

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -11,7 +11,6 @@ on:
       working-directory:
         type: string
         required: false
-        default: "."
       only-new-issues:
         type: boolean
         required: false

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -7,6 +7,11 @@ on:
         required: true
       ECR_REGISTRY:
         required: true
+    inputs:
+      working-directory:
+        type: string
+        required: false
+        default: "."
 
 jobs:
   lint:
@@ -15,7 +20,6 @@ jobs:
     runs-on: [self-hosted, bear]
 
     steps:
-
       - name: Check out Git repository
         uses: actions/checkout@v2
 
@@ -49,7 +53,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.9'
+          go-version: "1.17.9"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
@@ -58,6 +62,7 @@ jobs:
           version: v1.45.2
           only-new-issues: true
           skip-go-installation: true
+          working-directory: ${{ inputs.working-directory }}
           args: --config lint-config/config/golangci.yaml --issues-exit-code=1
 
       - name: Comment body


### PR DESCRIPTION
Adds two new workflow inputs called `working-directory` and `only-new-issues`, which are then passed to `golangci-lint`; uses an absolute path when referencing `lint-config/`.

This enables using this workflow in monorepos where Go code is not at the repo root, like Blocks.

Here's [a GHA run failing before these changes](https://github.com/Typeform/blocks/runs/6350623742?check_suite_focus=true#step:9:28), and [another passing after these changes](https://github.com/Typeform/blocks/runs/6351071046?check_suite_focus=true#step:9:57).