### PR TITLE
feat(PA-493): [go-lint-workflow] Allow set go version

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -19,6 +19,10 @@ on:
         type: string
         required: false
         default: "1.17.9"
+      golangci-lint-version:
+        type: string
+        required: false
+        default: "v1.45.2"
 
 jobs:
   lint:
@@ -66,7 +70,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         id: golangci-lint
         with:
-          version: v1.45.2
+          version: ${{ inputs.golangci-lint-version }}
           only-new-issues: ${{ inputs.only-new-issues }}
           skip-go-installation: true
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -15,6 +15,10 @@ on:
         type: boolean
         required: false
         default: true
+      go-version:
+        type: string
+        required: false
+        default: "1.17.9"
 
 jobs:
   lint:
@@ -56,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.9"
+          go-version: ${{ inputs.go-version }}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
We are experiencing a weird behavior from the linter. I think it is related to the go version.

Check: https://github.com/Typeform/performance-analytics-api/actions/runs/2635979121


[it works](https://github.com/Typeform/performance-analytics-api/actions/runs/2636367429)