### PR TITLE
build(NOJIRA-1234): migrate GHA runners to ephemeral

### DIFF
--- a/.github/workflows/fod-sast-scan.yaml
+++ b/.github/workflows/fod-sast-scan.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   FoD-SAST-Scan:
-    runs-on: [self-hosted, automated-checks]
+    runs-on: [self-hosted, automated-checks-ephemeral]
 
     steps:
       - name: Check Out Source Code

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -20,7 +20,7 @@ jobs:
   lint:
     if: ${{ !contains('Bot', github.event.pull_request.user.type) }}
     name: Run linter
-    runs-on: [self-hosted, bear]
+    runs-on: [self-hosted, bear-ephemeral]
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
Updates GHA runners to ephemeral runners. For more info check [this](https://www.notion.so/typeform/Migration-to-Ephemeral-runners-ffd85bafaed44cfd8a0c135701c4a6a7)

[_Created by Sourcegraph batch change `bruno.ferreira/migrate-gha-runners-to-ephemeral`._](https://sourcegraph.tools.typeform.tf/users/bruno.ferreira/batch-changes/migrate-gha-runners-to-ephemeral)