### PR TITLE
feat(WEB-5896): add update comment capabilites to deploy links workflow

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -12,6 +12,10 @@ on:
       version:
         type: string
         required: true
+      update-comment:
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   comment:
@@ -58,14 +62,36 @@ jobs:
             return linkList.join('\n')
           result-encoding: string
 
-      - name: Comment PR with deploy link(s)
-        uses: actions/github-script@v6
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        if:  inputs.update-comment
+        continue-on-error: true
+        id: find-comment
         with:
-          script: |
-            const body = `🎉 Version \`${{ inputs.version }}\` created, hooray!\n\n🚀 Deploy this version in an **ephemeral environment** with \`--reference\`:\n${{ steps.set-result.outputs.result }}`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
+          issue-number: ${{ github.event.number }}
+          body-includes: '🚀 Deploy this version in'
+
+      - name: Create Comment
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.find-comment.outputs.comment-id == ''
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## 🎉 Version `${{ inputs.version }}` created, hooray!
+            🚀 Deploy this version in an **ephemeral environment** with `--reference`:
+            ${{ steps.set-result.outputs.result }}
+
+      - name: Update Comment
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.find-comment.outputs.comment-id != '' && inputs.update-comment
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## 🎉 Version `${{ inputs.version }}` created, hooray!
+            🚀 Deploy this version in an **ephemeral environment** with `--reference`:
+            ${{ steps.set-result.outputs.result }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace

--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            ## 🎉 Version `${{ inputs.version }}` created, hooray!
+            🎉 Version `${{ inputs.version }}` created, hooray!
             🚀 Deploy this version in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
 
@@ -90,7 +90,7 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            ## 🎉 Version `${{ inputs.version }}` created, hooray!
+            🎉 Version `${{ inputs.version }}` created, hooray!
             🚀 Deploy this version in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
This PR adds a feature to comment-deploy-link reusable workflow.

In Web team we have identified the need to add this feature to this workflow.

We want to keep the content in the PR to its minimun so every comment is meaningful.

In order to avoid a breaking change, this new feature is **OPTIONAL**. The only new thing that needs to be added to the *caller* workflow is a new input called `update-comment: true`

[You can see a draft PR where this new feature has been tested](https://github.com/Typeform/public-main-site/pull/2949)
