### PR TITLE
chore: runs-on optional input ARCH-97

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -16,11 +16,17 @@ on:
         type: boolean
         required: false
         default: false
+      runs-on:
+        type: string
+        required: false
+        default: fear-ephemeral
 
 jobs:
   comment:
     name: Comment link
-    runs-on: [self-hosted, fear-ephemeral]
+    runs-on:
+      - self-hosted
+      - ${{ inputs.runs-on }}
 
     steps:
       - name: Get deploy link(s)


### PR DESCRIPTION
### Description

Adds new optional input `runs-on` for `comment-deploy-link` shared workflow

Defaults to previous value `fear-ephemeral`

🟢  Tested in `formsapi`: https://github.com/Typeform/forms-api/pull/549