### PR TITLE
chore(SEC-4091): update steps in fod that use node 12

### DIFF
--- a/.github/workflows/fod-sast-scan.yaml
+++ b/.github/workflows/fod-sast-scan.yaml
@@ -25,19 +25,20 @@ jobs:
 
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
       
       # Java 8 required by FoD Uploader
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: '11'
       
       # Pack source code
       - name: Zip source code
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@v1.1
         with:
           files: ${{ inputs.files }}
           dest: source.zip

--- a/.github/workflows/fod-sast-scan.yaml
+++ b/.github/workflows/fod-sast-scan.yaml
@@ -31,10 +31,10 @@ jobs:
       
       # Java 8 required by FoD Uploader
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '17'
       
       # Pack source code
       - name: Zip source code


### PR DESCRIPTION
[Github is deprecating the usage of NodeJS 12 in Github Actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This PR updates the Github Actions used by the workflow `fod-sast-scan.yaml` which use NodeJS 12.

The PR has been tested in this [sampler branch](https://github.com/Typeform/sampler/tree/SEC-4091-update-node-actions) with [success](https://github.com/Typeform/sampler/actions/runs/4054073574/).