### PR TITLE
chore(golangci-lint): Update default version to v1.51.0 (ARCH-121)

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -22,7 +22,7 @@ on:
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.45.2"
+        default: "v1.50.1"
 
 jobs:
   lint:

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -22,7 +22,7 @@ on:
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.50.1"
+        default: "v1.51.0"
 
 jobs:
   lint:


### PR DESCRIPTION
Follow our detailed thought process here: https://typeform.slack.com/archives/C2C0NBBJS/p1675255536771549

TL;DR: 
The default linter and go versions are (very) outdated; teams have moved up their go version once they could, and they should continue to have that freedom, which is why we do not want to touch the linter workflow's go version right now. The old default linter version does not work well with new go versions (see https://github.com/golangci/golangci-lint-action/issues/545), so we want to update the golangci-lint default to its newest version. With this change, we are betting (a hedged bet, since I made a couple of tests) that golangci-lint is fully backwards-compatible.
In the unexpected case (I did some tests) that this would break workflows of other teams, we'll rollback and recommend to override both versions (or none).