### PR TITLE
feat(NOJIRA-1234): Add new godoc to html action

### DIFF
--- a/shared-actions/godoc-to-html/Dockerfile
+++ b/shared-actions/godoc-to-html/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.19.3-alpine3.16
+
+ENV GOPATH=/go
+
+RUN apk add --update \
+    wget
+
+RUN go install golang.org/x/tools/cmd/godoc@v0.2.0
+
+COPY /entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/shared-actions/godoc-to-html/README.md
+++ b/shared-actions/godoc-to-html/README.md
@@ -1,0 +1,10 @@
+**Godoc to HTML**
+
+New action to generate HTML godocs from a Go repository.
+It automatically searches the `go.mod` file, builds the go docs, and downloads all the pages, linking them properly.
+It creates a new `godocs` directory in the GH workspace with all the documentation.
+
+**Usage example**
+
+In the `blocks` repository, we use the `godoc-to-html` action, deploy a preview with `surge.sh` and deploy the end version to GitHub pages, as you can see here: https://github.com/Typeform/blocks/pull/1340
+The output: https://typeform.design/blocks/godocs/go.html

--- a/shared-actions/godoc-to-html/action.yml
+++ b/shared-actions/godoc-to-html/action.yml
@@ -1,0 +1,5 @@
+name: 'Godoc to HTML'
+description: 'Gets godoc documentation from your repo in HTML format'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/shared-actions/godoc-to-html/entrypoint.sh
+++ b/shared-actions/godoc-to-html/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+PATH_GOMOD="$(dirname "$(find . -name 'go.mod' | head -n 1)")" || exit 1
+cd $PATH_GOMOD
+
+mkdir -p "$GOPATH/src/github.com/$GITHUB_REPOSITORY"
+cp -r * "$GOPATH/src/github.com/$GITHUB_REPOSITORY"
+
+go mod vendor
+godoc -v -http=:6060 &
+
+REPO=$GITHUB_REPOSITORY
+if [ $PATH_GOMOD != "." ]
+then
+  REPO="${GITHUB_REPOSITORY}${PATH_GOMOD:1}"
+fi
+
+echo $REPO
+
+wget -p -r -l8 -E -k -nH -q --include-directories="/lib,/pkg/github.com/$REPO,/src/github.com/$REPO" --exclude-directories="/pkg/github.com/$REPO/vendor,/src/github.com/$REPO/vendor" --no-host-directories --directory-prefix=godocs http://localhost:6060/pkg/github.com/$REPO
+
+chmod -R 777 godocs
+find ./godocs -type f -iname "*[?]*" -delete
+mv godocs /github/workspace/
+
+exit 0


### PR DESCRIPTION
**Summary**

This PR includes a new action to generate HTML go docs from a Go repository.
It automatically searches the `go.mod` file, builds the go docs, and downloads all the pages, linking them properly.
It creates a new `godocs` directory in the GH workspace with all the documentation.

**Usage example**

In `blocks`, we use the `godoc-to-html` action, deploy a preview with `surge.sh` and deploy the end version to GitHub pages, as you can see here: https://github.com/Typeform/blocks/pull/1340
The output: https://typeform.design/blocks/godocs/go.html

**Pending**
- [ ] Add Readme file.