### PR TITLE
chore(SP-2312): Remove the FoD-SAST-Scan job

### DIFF
--- a/reusable-workflows/fortify-on-demand/workflow.yaml
+++ b/reusable-workflows/fortify-on-demand/workflow.yaml
@@ -1,1 +1,0 @@
-../../.github/workflows/fod-sast-scan.yaml


### PR DESCRIPTION
### Description
The FoD license has expired and the FoD-SAST-Scan job can not be performed.
That means the job raises a warning. The job failure is not blocking any process.

We will take the following action:

Remove the fod-sast-scan.yaml file from the repository