### PR TITLE
feat(golint): Update default go version to v1.19.11

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -18,7 +18,7 @@ on:
       go-version:
         type: string
         required: false
-        default: "1.19.11"
+        default: "1.19.12"
       golangci-lint-version:
         type: string
         required: false

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -18,11 +18,11 @@ on:
       go-version:
         type: string
         required: false
-        default: "1.17.9"
+        default: "1.19.11"
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.51.0"
+        default: "v1.53.3"
 
 jobs:
   lint:


### PR DESCRIPTION
The current go versions we specify as default versions for the linter are so very old that they are not even supported any longer. Updating it to golang v1.19, because that is the oldest supported version.

Note that these are the _default_ versions, if there is any case that a service needs to use an older go version, one can overwrite the defaults like this: 

```
    with:
      go-version: "1.20.5"
      golangci-lint-version: "v1.53.2"
```
(example: https://github.com/Typeform/forms-api/blob/b9383c8234dad5a8c19478ed5e01de5d2a0c5eef/.github/workflows/lint.yaml#L12)

See also https://www.notion.so/typeform/Use-supported-runtime-versions-4336ec1006ca4a9da53c6f57e914296e#fce1c1bce18b4e61b834440907dc0ba9 for some additional information and motivation.

See also https://typeform.slack.com/archives/CPKBRDQPQ/p1691056721928979 for the discussion that triggered this update now.