### PR TITLE
fix(NOJIRA-123): trigger ci-standard-checks on draft->ready PR transition

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
     branches:
       - main
 


### PR DESCRIPTION
Since `additionalChecks` was implemented in `ci-standard-checks`, some checks only run on PRs that are marked as "Ready for review" and are ignored on Draft PRs.
This means that for PRs that are opened in Draft and then marked as Ready for review without adding any new commits, CI Standard Checks will never execute `additionalChecks`.

This PR adds the `ready_for_review` PR event type to the CI Standard Checks workflow template.