### PR TITLE
[NOJIRA-123] fix(comment-deploy-link): do not break when a single quote is on title

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Get deploy link(s)
         uses: actions/github-script@v6
         id: set-result
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BRANCH_NAME: ${{ github.head_ref }}
         with:
           script: |
             const getJiraId = (text) => {
@@ -47,8 +50,8 @@ jobs:
             }
             
             const references = new Set()
-            const prTitle = `${{ github.event.pull_request.title }}`
-            const branchName = `${{ github.head_ref }}`
+            const prTitle = process.env.PR_TITLE
+            const branchName = process.env.BRANCH_NAME
             const prTitleJiraId = getJiraId(prTitle)
             const branchNameJiraId = getJiraId(branchName)
 


### PR DESCRIPTION
This commit fixes the GitHub Action so that it prevents that a pull request title containing the ` character breaks.

This is fixed by reading these values (branch and pr title) as strings from environment variables instead of interpolating these in the script, as recommented by
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

This screenshot belongs to this [failed job](https://github.com/Typeform/smart-insights/actions/runs/6048827159/job/16415419029?pr=28)
<img width="836" alt="Screenshot 2023-09-01 at 17 13 12" src="https://github.com/Typeform/.github/assets/2795033/1382c183-ec85-400c-ab00-d7aa7e68dd29">
