### PR TITLE
feat(PR-41): add a shared CI standard checks workflow

### DIFF
--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -1,0 +1,33 @@
+name: CI Standard Checks Workflow
+
+on:
+  workflow_call:
+    inputs:
+      skipChecks:
+        required: true
+        default: ''
+        description: 'Checks to be skipped'
+      enableChecks:
+        required: true
+        default: ''
+        description: 'Optional checks to enable'
+      githubToken:
+        required: true
+        description: 'The github token to get PR info when checking for Jira Issue key'
+
+jobs:
+  ci-standard-checks:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Check Out Source Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: CI Standard Checks
+        uses: Typeform/ci-standard-checks@v1
+        with:
+          githubToken: ${{ inputs.githubToken }}
+          skipChecks: ${{ inputs.skipChecks }}
+          enableChecks: ${{ inputs.enableChecks }}
+

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -7,10 +7,12 @@ on:
         required: true
     inputs:
       skipChecks:
+        type: string
         required: true
         default: ''
         description: 'Checks to be skipped'
       enableChecks:
+        type: string
         required: true
         default: ''
         description: 'Optional checks to enable'

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -2,6 +2,9 @@ name: CI Standard Checks Workflow
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
     inputs:
       skipChecks:
         required: true
@@ -11,9 +14,6 @@ on:
         required: true
         default: ''
         description: 'Optional checks to enable'
-      githubToken:
-        required: true
-        description: 'The github token to get PR info when checking for Jira Issue key'
 
 jobs:
   ci-standard-checks:
@@ -27,7 +27,7 @@ jobs:
       - name: CI Standard Checks
         uses: Typeform/ci-standard-checks@v1
         with:
-          githubToken: ${{ inputs.githubToken }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           skipChecks: ${{ inputs.skipChecks }}
           enableChecks: ${{ inputs.enableChecks }}
 

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -2,9 +2,6 @@ name: CI Standard Checks Workflow
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
     inputs:
       skipChecks:
         type: string

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -8,12 +8,12 @@ on:
     inputs:
       skipChecks:
         type: string
-        required: true
+        required: false
         default: ''
         description: 'Checks to be skipped'
       enableChecks:
         type: string
-        required: true
+        required: false
         default: ''
         description: 'Optional checks to enable'
 

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -3,7 +3,7 @@ name: CI Standard Checks Workflow
 on:
   workflow_call:
     secrets:
-      GH_TOKEN:
+      GITHUB_TOKEN:
         required: true
     inputs:
       skipChecks:
@@ -29,6 +29,6 @@ jobs:
       - name: CI Standard Checks
         uses: Typeform/ci-standard-checks@v1
         with:
-          githubToken: ${{ secrets.GH_TOKEN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           skipChecks: ${{ inputs.skipChecks }}
           enableChecks: ${{ inputs.enableChecks }}

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -3,7 +3,7 @@ name: CI Standard Checks Workflow
 on:
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         required: true
     inputs:
       skipChecks:
@@ -27,7 +27,7 @@ jobs:
       - name: CI Standard Checks
         uses: Typeform/ci-standard-checks@v1
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          githubToken: ${{ secrets.GH_TOKEN }}
           skipChecks: ${{ inputs.skipChecks }}
           enableChecks: ${{ inputs.enableChecks }}
 

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -32,4 +32,3 @@ jobs:
           githubToken: ${{ secrets.GH_TOKEN }}
           skipChecks: ${{ inputs.skipChecks }}
           enableChecks: ${{ inputs.enableChecks }}
-

--- a/reusable-workflows/ci-standard-checks/workflow.yaml
+++ b/reusable-workflows/ci-standard-checks/workflow.yaml
@@ -1,0 +1,1 @@
+../../.github/workflows/ci-standard-checks-workflow.yaml


### PR DESCRIPTION
Add a new workflow for CI standard checks. We will use it to use the 50k free minutes we have with Github.

https://typeform.slack.com/archives/CCWDN8ASJ/p1704726455798989