### PR TITLE
chore(PR-41): use automated-checks runner on go lint workflow and update actions

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -28,18 +28,18 @@ jobs:
   lint:
     if: ${{ !contains('Bot', github.event.pull_request.user.type) }}
     name: Run linter
-    runs-on: [self-hosted, bear-ephemeral]
+    runs-on: [self-hosted, automated-checks-ephemeral]
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Parse Repository Name
         id: repo-name
         run: echo "name=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_OUTPUT
 
       - name: Check out repository containing linter config
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Typeform/golang-builder
           ref: main
@@ -62,7 +62,7 @@ jobs:
           export GOPRIVATE=github.com/Typeform/*
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
 


### PR DESCRIPTION
Using `bear` runners (which are quite beefy) to run the linting workflow seems overkill, moreover since this workflow is usually ran in parallel to the actual build/test/deploy workflows, it is not critical that it runs as fast as possible.  

Actions were updated and although major version changes, don't seem to have breaking changes.