### PR TITLE
chore(PR-1): run comment-deploy-link on ubuntu-latest

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -16,17 +16,11 @@ on:
         type: boolean
         required: false
         default: false
-      runs-on:
-        type: string
-        required: false
-        default: fear-ephemeral
 
 jobs:
   comment:
     name: Comment link
-    runs-on:
-      - self-hosted
-      - ${{ inputs.runs-on }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Get deploy link(s)

--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -16,6 +16,10 @@ on:
         type: boolean
         required: false
         default: false
+      runs-on:
+        type: string
+        required: false
+        default: fear-ephemeral
 
 jobs:
   comment:


### PR DESCRIPTION
This workflow does not need to run on a self-hosted runner, since it only creates a comment in the PR. It frees up space for more heavy workflows to use the self-hosted runners.