### PR TITLE
PR-41-improve-ci-standards-check

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -4,21 +4,14 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, edited, synchronize, reopened, ready_for_review]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
-
 jobs:
   ci-standard-checks:
-    runs-on: [ubuntu-latest]
-
-    steps:
-      - name: Check Out Source Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: CI Standard Checks
-        uses: Typeform/ci-standard-checks@v1
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+    uses: Typeform/.github/.github/workflows/ci-standard-checks-workflow.yaml@v1


### PR DESCRIPTION
use central ci-standards-check template for https://www.notion.so/typeform/Github-Actions-Runners-revamp-d67c03f3dfb949d1a22a7abfe8c249d2

[_Created by Sourcegraph batch change `engineering-intelligence/PR-41-improve-ci-standards-check`._](https://sourcegraph.tools.typeform.tf/users/engineering-intelligence/batch-changes/PR-41-improve-ci-standards-check)