### PR TITLE
chore(PR-41): skip vendor folder in go lint workflow

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -73,7 +73,7 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
-          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --issues-exit-code=1
+          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1
 
       - name: Comment body
         id: comment-body-content


### PR DESCRIPTION
Some of the workflows are caching the `vendor` folder and `golangci-lint` is linting it, which it shouldn't. By skipping it, we will see an improvement in the worfklow run times for those projects :) 