### PR TITLE
fix(PR-41): disable caching in setup-go

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
+          cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Disable caching which was enabled by default in version `v4`, so we can keep the same behaviour as before.