### PR TITLE
feat: workflow to start using node20 AI-1061

### DIFF
--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: CI Standard Checks
         uses: Typeform/ci-standard-checks@v1
         with:


### PR DESCRIPTION
### Description

Since we are using a latest ubuntu version, we need to specify the proper node version

A new ci-standard-checks version has already been released, with support for node 20 (see https://github.com/Typeform/ci-standard-checks/pull/175)

Tested in toltec: https://github.com/Typeform/toltec/pull/437

Fixes the following problem
![image](https://github.com/Typeform/.github/assets/71030893/3271e89a-c2c2-43d1-81bd-3c9da446e5c6)
