### PR TITLE
feat(workflow): update runner to rename bear to ci-base

### DIFF
--- a/.github/workflows/image-multiarch.yaml
+++ b/.github/workflows/image-multiarch.yaml
@@ -31,7 +31,7 @@ on:
 jobs:
   build:
     name: Build and push image
-    runs-on: [ self-hosted, bear-graviton ]
+    runs-on: [ self-hosted, ci-basej
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Scope 

Updaing the GHA workflow to use the new naming convention and remove the bear notation, as per: https://www.notion.so/typeform/GHA-graviton-migration-42535d1facd0404cac2f628ec92d4b06