### PR TITLE
feat(lint): bump action version and timeout

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -74,7 +74,7 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
-          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1
+          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --exclude-dirs="(^|/)vendor($|/)" --issues-exit-code=1
 
       - name: Comment body
         id: comment-body-content

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -68,13 +68,13 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         id: golangci-lint
         with:
           version: ${{ inputs.golangci-lint-version }}
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
-          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --exclude-dirs="(^|/)vendor($|/)" --issues-exit-code=1
+          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1 --verbose --timeout=5m
 
       - name: Comment body
         id: comment-body-content

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -74,7 +74,7 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
-          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1 --verbose --timeout=5m
+          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1 --timeout=3m
 
       - name: Comment body
         id: comment-body-content


### PR DESCRIPTION
## CHANGES
- bumps `golangci/golangci-lint-action` to `v4`
- increases default timeout (1m) to `3m`