### PR TITLE
feat(go-lint-workflow): run using GH hosted runner ubuntu

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -28,7 +28,7 @@ jobs:
   lint:
     if: ${{ !contains('Bot', github.event.pull_request.user.type) }}
     name: Run linter
-    runs-on: [self-hosted, automated-checks-ephemeral]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
This workflow runs fine on the tested repositories and while the time it takes to run was observed to be a bit slower than the self-hosted runner, it shouldn't impact DX as this workflow still takes roughly (but often less than) ~2min to run.

