### PR TITLE
fix(dependabot): prefix with fix to trigger releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       patterns:
         - "*"
   commit-message:
-    prefix: chore(bot)
+    prefix: fix(bot)


### PR DESCRIPTION
# Overview

Prefix dependabot commits/PRs with `fix` instead of `chore`, s.t. running the release action will create a new release/tag for this package. This is needed so that all consuming repositories get dependent GHA updates.