### PR TITLE
[PRODINOPS-450] Bump golangci-lint and Go versions

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -22,11 +22,11 @@ on:
       go-version:
         type: string
         required: false
-        default: "1.22.5"
+        default: "1.23.1"
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.60.3"
+        default: "v1.61.0"
 
 jobs:
   lint:


### PR DESCRIPTION
- Go bumped to 1.23.1
- golangci-lint bumped to 1.61.0


This fixes issues between the old linter and newer version of Go (1.23).