### PR TITLE
fix(ci-standards-check): allow to use beta version in workflow

### DIFF
--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
         description: 'Optional checks to enable'
+      useBeta:
+        type: boolean
+        required: false
+        default: false
+        description: 'whether to use Typeform/ci-standard-checks@v1-beta'
 
 jobs:
   ci-standard-checks:
@@ -27,7 +32,15 @@ jobs:
         with:
           node-version: 20
       - name: CI Standard Checks
+        if: !inputs.useBeta
         uses: Typeform/ci-standard-checks@v1
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          skipChecks: ${{ inputs.skipChecks }}
+          enableChecks: ${{ inputs.enableChecks }}
+      - name: CI Standard Checks @v1-beta
+        if: inputs.useBeta
+        uses: Typeform/ci-standard-checks@v1-beta
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           skipChecks: ${{ inputs.skipChecks }}


### PR DESCRIPTION
For testing purposes before publishing `Typeform/ci-standards-checks` to `@v1` it would be nice to be able to test whether the newest update would break something.

Because repositories reference the workflow, not the `Typeform/ci-standards-check`, this was only possible when updating the workflow, which is a bit inconvenient.

We cannot pass in an arbitrary version, as GHA do not allow that in `uses`. 