### PR TITLE
ci(ci-standard-checks): test new ci-standard-checks [PLT-1]

### DIFF
--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 20
       - name: CI Standard Checks
-        if: !inputs.useBeta
+        if: ${{ inputs.useBeta == false }}
         uses: Typeform/ci-standard-checks@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 20
       - name: CI Standard Checks
-        if: ${{ inputs.useBeta == false }}
+        if: !inputs.useBeta
         uses: Typeform/ci-standard-checks@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ci-standard-checks-workflow.yaml
+++ b/.github/workflows/test-ci-standard-checks-workflow.yaml
@@ -1,0 +1,9 @@
+name: Test CI Standard Checks (this PR)
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  ci-standard-checks:
+    uses: ./.github/workflows/ci-standard-checks-workflow.yaml


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-1

After recent events, trying to make this me-proof, i.e., adding a run for the ci-standard-check that was changed in the same PR.

Part of this will be making the "Test CI standard check" check mandatory.