### PR TITLE
ci(ci-standard-checks): rename job so it can be used in required checks

### DIFF
--- a/.github/workflows/test-ci-standard-checks-workflow.yaml
+++ b/.github/workflows/test-ci-standard-checks-workflow.yaml
@@ -5,5 +5,5 @@ on:
     branches:
       - main
 jobs:
-  ci-standard-checks:
+  test-ci-standard-checks:
     uses: ./.github/workflows/ci-standard-checks-workflow.yaml


### PR DESCRIPTION
Need to give it a different name or the "Required status checks" UI does not find it.