### PR TITLE
feat(go-lint): bump to latest versions in golang-builder

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -22,11 +22,11 @@ on:
       go-version:
         type: string
         required: false
-        default: "1.23.5"
+        default: "1.24.0"
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.63.4"
+        default: "v1.64.4"
 
 jobs:
   lint:


### PR DESCRIPTION
Bump the go and golangci-lint _default_ versions in the `go-lint` flow, as [golang-builder uses them in its newest version](https://github.com/Typeform/golang-builder/blob/1.14.5-go1.24.0/Makefile#L14-L15).