### PR TITLE
fix(golangci-lint): do not verify schema

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -66,6 +66,7 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
+          verify: false # no need to verify, we know golang-builder has a valid config
           args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1 --timeout=${{ inputs.timeout }}
 
       - name: Comment body


### PR DESCRIPTION
`golangci/golangci-lint-action@v6` always verifies the local `.golangci.yaml`, there is no way to pass it a config file explicitly. It does not respect the one passed in `args`, which is only passed to `golangci-lint` command itself.

It is also not really necessary to check this file on every repo, as it is the same one, downloaded from `golang-builder`'s `main` branch. Therefore, will add this verification step to `golang-builder`'s CI, and pass `verify: false` in the `go-lint` standard linting flow here.