### PR TITLE
fix(go-lint): remove args that are the default already

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -67,7 +67,7 @@ jobs:
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
           verify: false # no need to verify, we know golang-builder has a valid config
-          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1 --timeout=${{ inputs.timeout }}
+          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --timeout=${{ inputs.timeout }}
 
       - name: Comment body
         id: comment-body-content


### PR DESCRIPTION
Jira: https://typeform.atlassian.net/browse/PLT-827

Remove `--skip-dirs="(^|/)vendor($|/)" --issues-exit-code=1`.

- `--skip-dirs="(^|/)vendor($|/)"`:  This option is deprecated. `vendor` directory is anyway the default of `exclude-dirs-use-default` which defaults to `true`: https://golangci-lint.run/usage/configuration/#command-line-options
- `--issues-exit-code=1`: This is the default already.