### PR TITLE
ci: semantic github release on push to main

### DIFF
--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -1,0 +1,22 @@
+name: Create GitHub Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  github-release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-909

Create a Github release automatically on each push to `main`.
We frequently forget this (see https://github.com/Typeform/.github/releases/tag/v1.8.0 which contains a lot of unrelated changes in one release), and it has no negative consequences, as all workflows are referenced with the `@v1` tag.

We still have to update the `v1` tag manually - we can keep doing it that way, or have some basic testing flow and push `v1` automatically after a GH release has been created.