### PR TITLE
Improve shared action for updating GraphQL-BFF AllowList

### DIFF
--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -74,7 +74,7 @@ jobs:
             curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}" \
               -H "Content-Type: application/json" \
               --data-binary "@generated/persisted-query-manifest.json" \
-            if [ $curl_exit_code -ne 0 ]; then
+            if [ $? -ne 0 ]; then
               echo "❌ Failed to upload manifest to $url with exit code $curl_exit_code"
             else
               echo "✅ Successfully uploaded to $url"

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -51,7 +51,12 @@ jobs:
           mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
           for url in "${ENDPOINTS[@]}"; do
             echo "Pinging $url..."
-            curl -v --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || echo ":x: $url is not reachable"
+            curl_exit_code=0
+            curl -v --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
+            if [ $curl_exit_code -ne 0 ]; then
+              echo "❌ Curl command failed with exit code $curl_exit_code"
+              exit $curl_exit_code
+            fi
           done
 
       - name: Extract app name from package.json
@@ -69,6 +74,15 @@ jobs:
             curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}" \
               -H "Content-Type: application/json" \
               --data-binary "@generated/persisted-query-manifest.json" \
-              && echo "✅ Successfully uploaded to $url" \
-              || echo "❌ Failed to upload to $url"
+            if [ $curl_exit_code -ne 0 ]; then
+              echo "❌ Failed to upload manifest to $url with exit code $curl_exit_code"
+            else
+              echo "✅ Successfully uploaded to $url"
+            fi
+          done
+
+          if [ $curl_exit_code -ne 0 ]; then
+            echo "❌ One or more uploads failed, failing workflow"
+            exit $curl_exit_code
+          fi
           done

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -7,7 +7,7 @@ on:
         required: true
 
 jobs:
-  generate:
+  update-allow-list:
     runs-on: [self-hosted, ci-universal]
     env:
       GRAPHQL_ENDPOINTS: |
@@ -30,18 +30,18 @@ jobs:
           npm config set '//npm.pkg.github.com/:_authToken' ${{ secrets.GH_TOKEN }}
           npm config set @typeform:registry https://npm.pkg.github.com/
 
-      # - name: Check if GraphQL endpoints are reachable
-      #   run: |
-      #     mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
-      #     for url in "${ENDPOINTS[@]}"; do
-      #       echo "Pinging $url..."
-      #       curl_exit_code=0
-      #       curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
-      #       if [ $curl_exit_code -ne 0 ]; then
-      #         echo "❌ Curl command failed with exit code $curl_exit_code"
-      #         exit $curl_exit_code
-      #       fi
-      #     done
+      - name: Check if GraphQL endpoints are reachable
+        run: |
+          mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
+          for url in "${ENDPOINTS[@]}"; do
+            echo "Pinging $url..."
+            curl_exit_code=0
+            curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
+            if [ $curl_exit_code -ne 0 ]; then
+              echo "❌ Curl command failed with exit code $curl_exit_code"
+              exit $curl_exit_code
+            fi
+          done
 
       - name: Install only @typeform/generate-persisted-operations-manifest
         run: yarn add --no-lockfile --non-interactive --dev @typeform/generate-persisted-operations-manifest

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -30,18 +30,18 @@ jobs:
           npm config set '//npm.pkg.github.com/:_authToken' ${{ secrets.GH_TOKEN }}
           npm config set @typeform:registry https://npm.pkg.github.com/
 
-      - name: Check if GraphQL endpoints are reachable
-        run: |
-          mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
-          for url in "${ENDPOINTS[@]}"; do
-            echo "Pinging $url..."
-            curl_exit_code=0
-            curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
-            if [ $curl_exit_code -ne 0 ]; then
-              echo "❌ Curl command failed with exit code $curl_exit_code"
-              exit $curl_exit_code
-            fi
-          done
+      # - name: Check if GraphQL endpoints are reachable
+      #   run: |
+      #     mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
+      #     for url in "${ENDPOINTS[@]}"; do
+      #       echo "Pinging $url..."
+      #       curl_exit_code=0
+      #       curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
+      #       if [ $curl_exit_code -ne 0 ]; then
+      #         echo "❌ Curl command failed with exit code $curl_exit_code"
+      #         exit $curl_exit_code
+      #       fi
+      #     done
 
       - name: Install only @typeform/generate-persisted-operations-manifest
         run: yarn add --no-lockfile --non-interactive --dev @typeform/generate-persisted-operations-manifest

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -35,7 +35,6 @@ jobs:
           readarray -t ENDPOINTS <<< "$GRAPHQL_ENDPOINTS"
           for url in "${ENDPOINTS[@]}"; do
             [[ -z "$url" ]] && continue  # skip empty lines
-
             echo "Pinging $url..."
             curl_exit_code=0
             curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
@@ -73,6 +72,7 @@ jobs:
           mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
           curl_exit_code=0
           for url in "${ENDPOINTS[@]}"; do
+            [[ -z "$url" ]] && continue  # skip empty lines
             echo "Uploading manifest to $url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${APP_NAME}"
             curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${APP_NAME}" \
               -H "Content-Type: application/json" \

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -69,13 +69,16 @@ jobs:
       - name: Upload manifest to internal allow list for all endpoints
         run: |
           mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
+          curl_exit_code=0
           for url in "${ENDPOINTS[@]}"; do
-            echo "Uploading manifest to $url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}"
-            curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}" \
+            echo "Uploading manifest to $url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${APP_NAME}"
+            curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${APP_NAME}" \
               -H "Content-Type: application/json" \
-              --data-binary "@generated/persisted-query-manifest.json" \
+              --data-binary "@generated/persisted-query-manifest.json"
+
             if [ $? -ne 0 ]; then
-              echo "❌ Failed to upload manifest to $url with exit code $curl_exit_code"
+              echo "❌ Failed to upload manifest to $url"
+              curl_exit_code=1
             else
               echo "✅ Successfully uploaded to $url"
             fi
@@ -85,4 +88,3 @@ jobs:
             echo "❌ One or more uploads failed, failing workflow"
             exit $curl_exit_code
           fi
-          done

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -30,18 +30,18 @@ jobs:
           npm config set '//npm.pkg.github.com/:_authToken' ${{ secrets.GH_TOKEN }}
           npm config set @typeform:registry https://npm.pkg.github.com/
 
-      # - name: Check if GraphQL endpoints are reachable
-      #   run: |
-      #     mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
-      #     for url in "${ENDPOINTS[@]}"; do
-      #       echo "Pinging $url..."
-      #       curl_exit_code=0
-      #       curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
-      #       if [ $curl_exit_code -ne 0 ]; then
-      #         echo "❌ Curl command failed with exit code $curl_exit_code"
-      #         exit $curl_exit_code
-      #       fi
-      #     done
+      - name: Check if GraphQL endpoints are reachable
+        run: |
+          IFS=$'\n' read -rd '' -a ENDPOINTS <<<"${GRAPHQL_ENDPOINTS}"
+          for url in "${ENDPOINTS[@]}"; do
+            echo "Pinging $url..."
+            curl_exit_code=0
+            curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
+            if [ $curl_exit_code -ne 0 ]; then
+              echo "❌ Curl command failed with exit code $curl_exit_code"
+              exit $curl_exit_code
+            fi
+          done
 
       - name: Install only @typeform/generate-persisted-operations-manifest
         run: yarn add --no-lockfile --non-interactive --dev @typeform/generate-persisted-operations-manifest

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -1,0 +1,72 @@
+name: "Generate persisted operations"
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  generate:
+    runs-on: [self-hosted, ci-universal]
+    env:
+      GRAPHQL_ENDPOINTS: |
+        https://graphqlbff.tfprod.internal.typeform.tf
+        https://graphqlbff.tfprod.internal.eu.typeform.tf
+        https://graphqlbff.tfprod.internal.eu-central-1.typeform.tf
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set GitHub packages registry
+        run: |
+          npm config set '//npm.pkg.github.com/:_authToken' ${{ secrets.GH_TOKEN }}
+          npm config set @typeform:registry https://npm.pkg.github.com/
+
+      - name: Install only @typeform/generate-persisted-operations-manifest
+        run: yarn add --no-lockfile --non-interactive --dev @typeform/generate-persisted-operations-manifest
+
+      - name: Generate Persisted Operations
+        run: node node_modules/@typeform/generate-persisted-operations-manifest/dist/index.js
+
+      - name: List generated files
+        run: |
+          echo "Listing contents of ./generated directory:"
+          ls -la generated
+
+      - name: Display persisted-query-manifest.json
+        run: |
+          echo "Contents of generated/persisted-query-manifest.json:"
+          cat generated/persisted-query-manifest.json
+
+      - name: Check if GraphQL endpoints are reachable
+        run: |
+          mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
+          for url in "${ENDPOINTS[@]}"; do
+            echo "Pinging $url..."
+            curl -v --max-time 10 "$url" || echo ":x: $url is not reachable"
+          done
+
+      - name: Upload manifest to internal allow list
+        run: |
+          curl --trace-ascii --max-time 30 -X PATCH https://graphqlbff.tfprod.internal.typeform.tf/internal/operation-allow-list \
+            -H "Content-Type: application/json" \
+            --data-binary "@generated/persisted-query-manifest.json"
+
+      - name: Upload manifest to internal allow list for all endpoints
+        run: |
+          mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
+          for url in "${ENDPOINTS[@]}"; do
+            echo "Uploading manifest to $url/internal/operation-allow-list..."
+            curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list" \
+              -H "Content-Type: application/json" \
+              --data-binary "@generated/persisted-query-manifest.json" \
+              && echo "✅ Successfully uploaded to $url" \
+              || echo "❌ Failed to upload to $url"
+          done

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -30,6 +30,19 @@ jobs:
           npm config set '//npm.pkg.github.com/:_authToken' ${{ secrets.GH_TOKEN }}
           npm config set @typeform:registry https://npm.pkg.github.com/
 
+      - name: Check if GraphQL endpoints are reachable
+        run: |
+          mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
+          for url in "${ENDPOINTS[@]}"; do
+            echo "Pinging $url..."
+            curl_exit_code=0
+            curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
+            if [ $curl_exit_code -ne 0 ]; then
+              echo "❌ Curl command failed with exit code $curl_exit_code"
+              exit $curl_exit_code
+            fi
+          done
+
       - name: Install only @typeform/generate-persisted-operations-manifest
         run: yarn add --no-lockfile --non-interactive --dev @typeform/generate-persisted-operations-manifest
 
@@ -45,19 +58,6 @@ jobs:
         run: |
           echo "Contents of generated/persisted-query-manifest.json:"
           cat generated/persisted-query-manifest.json
-
-      - name: Check if GraphQL endpoints are reachable
-        run: |
-          mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
-          for url in "${ENDPOINTS[@]}"; do
-            echo "Pinging $url..."
-            curl_exit_code=0
-            curl -v --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?
-            if [ $curl_exit_code -ne 0 ]; then
-              echo "❌ Curl command failed with exit code $curl_exit_code"
-              exit $curl_exit_code
-            fi
-          done
 
       - name: Extract app name from package.json
         run: |

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
           for url in "${ENDPOINTS[@]}"; do
-            echo "Uploading manifest to $url/internal/operation-allow-list..."
+            echo "Uploading manifest to $url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}"
             curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}" \
               -H "Content-Type: application/json" \
               --data-binary "@generated/persisted-query-manifest.json" \

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: [self-hosted, ci-universal]
     env:
       GRAPHQL_ENDPOINTS: |
+        https://graphqlbff.staging.internal.tfdev.typeform.tf
         https://graphqlbff.tfprod.internal.typeform.tf
         https://graphqlbff.tfprod.internal.eu.typeform.tf
         https://graphqlbff.tfprod.internal.eu-central-1.typeform.tf
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Set GitHub packages registry
         run: |
@@ -50,21 +51,22 @@ jobs:
           mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
           for url in "${ENDPOINTS[@]}"; do
             echo "Pinging $url..."
-            curl -v --max-time 10 "$url" || echo ":x: $url is not reachable"
+            curl -v --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || echo ":x: $url is not reachable"
           done
 
-      - name: Upload manifest to internal allow list
+      - name: Extract app name from package.json
         run: |
-          curl --trace-ascii --max-time 30 -X PATCH https://graphqlbff.tfprod.internal.typeform.tf/internal/operation-allow-list \
-            -H "Content-Type: application/json" \
-            --data-binary "@generated/persisted-query-manifest.json"
+          echo "APP_NAME=$(jq -r '.name' package.json | sed 's/@typeform\///')" >> $GITHUB_ENV
+
+      - name: Print extracted app name
+        run: echo "Extracted APP_NAME is ${{ env.APP_NAME }}"
 
       - name: Upload manifest to internal allow list for all endpoints
         run: |
           mapfile -t ENDPOINTS <<< "${GRAPHQL_ENDPOINTS}"
           for url in "${ENDPOINTS[@]}"; do
             echo "Uploading manifest to $url/internal/operation-allow-list..."
-            curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list" \
+            curl --fail --max-time 30 -X PATCH "$url/internal/operation-allow-list?deploymentRunNumber=$GITHUB_RUN_NUMBER&appName=${{env.APP_NAME}}" \
               -H "Content-Type: application/json" \
               --data-binary "@generated/persisted-query-manifest.json" \
               && echo "✅ Successfully uploaded to $url" \

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           readarray -t ENDPOINTS <<< "$GRAPHQL_ENDPOINTS"
           for url in "${ENDPOINTS[@]}"; do
+            [[ -z "$url" ]] && continue  # skip empty lines
+
             echo "Pinging $url..."
             curl_exit_code=0
             curl --max-time 10 "$url?runNumber=$GITHUB_RUN_NUMBER" || curl_exit_code=$?

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check if GraphQL endpoints are reachable
         run: |
-          IFS=$'\n' read -rd '' -a ENDPOINTS <<<"${GRAPHQL_ENDPOINTS}"
+          readarray -t ENDPOINTS <<< "$GRAPHQL_ENDPOINTS"
           for url in "${ENDPOINTS[@]}"; do
             echo "Pinging $url..."
             curl_exit_code=0

--- a/reusable-workflows/graphql-generate-persisted-operations/graphql-generate-persisted-operations.yml
+++ b/reusable-workflows/graphql-generate-persisted-operations/graphql-generate-persisted-operations.yml
@@ -1,0 +1,1 @@
+../../.github/workflows/graphql-generate-persisted-operations.yml


### PR DESCRIPTION
Makes the shared action fail if updating AllowList fails - this will cause the PR to fail, which ensures that no new queries can make it to production code with first having been registered in GraphQL-BFF's AllowList