### PR TITLE
feat(NOJIRA-1): add merge queue event on ci-standard-checks

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -12,6 +12,8 @@ on:
       - ready_for_review
     branches:
       - main
+  merge_group:
+    types: [ checks_requested ]
 jobs:
   ci-standard-checks:
     uses: Typeform/.github/.github/workflows/ci-standard-checks-workflow.yaml@v1


### PR DESCRIPTION
We are adding a merge queue into builder. This PR is adding `merge_group` event to the `ci-standard-checks` action.