### PR TITLE
feat(NOJIRA-123): deploy docs action

### DIFF
--- a/shared-actions/docs/README.md
+++ b/shared-actions/docs/README.md
@@ -43,7 +43,7 @@ jobs:
 | `path`       | Yes      | `docs`                        | Path to pre-built documentation directory |
 | `target`     | No       | `s3`                          | Deployment target: `s3` or `github`       |
 | `bucket`     | No       | `typeform-design-docs-vblxnu` | S3 bucket name                            |
-| `prefix`     | No       | Repository name               | S3 prefix for organization                |
+| `prefix`     | No       | `<repo-name>/<branch>`        | S3 prefix for organization                |
 | `aws-region` | No       | `us-east-1`                   | AWS region for S3                         |
 
 ## Output Parameters
@@ -51,6 +51,26 @@ jobs:
 | Parameter  | Description                              |
 | ---------- | ---------------------------------------- |
 | `docs-url` | URL where the documentation was deployed |
+
+## S3 Prefix and TTL Behavior
+
+### Default Prefix Format
+
+When no custom `prefix` is specified, the action uses the format: `<repository-name>/<branch-name>`
+
+Examples:
+
+- `my-repo/main` - for main branch deployments
+- `my-repo/feature-branch` - for feature branch deployments
+- `other-repo/PR-123` - for pull request branch deployments
+
+### TTL (Time To Live) for Non-Main Branches
+
+- **Main branch**: Files are uploaded without expiration (permanent)
+- **Other branches with default prefix**: Files are uploaded with a 1-month TTL to prevent storage bloat from temporary branches
+- **Custom prefix**: No TTL is applied regardless of branch (user controls the lifecycle)
+
+This ensures that documentation for feature branches and pull requests is automatically cleaned up after 30 days when using the default prefix format, while main branch documentation and custom prefix deployments remain permanently available.
 
 ## Examples
 

--- a/shared-actions/docs/README.md
+++ b/shared-actions/docs/README.md
@@ -1,0 +1,142 @@
+# Docs Action
+
+This repository contains a GitHub Action to upload and deploy pre-built documentation for a project to the [Typeform internal Docs Hub](https://docs.typeform.com/).
+
+This action expects documentation to already be built and uploads it to:
+
+- S3: the `typeform-design-docs-vblxnu` S3 bucket using AWS CLI, by default
+- GitHub Pages: the `gh-pages` branch of the repository, if you prefer to deploy there
+
+It authenticates with AWS using the GHA IAM role `typeform-docs-action`, which is assumed by a workflow step.
+
+## Usage
+
+To invoke this action, you can do like the following:
+
+```yaml
+name: Generate and deploy docs
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For AWS IAM role assumption
+      contents: read # For repository access
+    steps:
+      - name: Deploy documentation
+        uses: Typeform/.github/shared-actions/docs@main
+        with:
+          path: "docs" # Path to the pre-built docs directory
+          target: "s3" # or 'github' for GitHub Pages
+          bucket: "your-bucket" # Optional, defaults to internal bucket
+          prefix: "your-prefix" # Optional, defaults to repository name
+```
+
+## Input Parameters
+
+| Parameter    | Required | Default                       | Description                               |
+| ------------ | -------- | ----------------------------- | ----------------------------------------- |
+| `path`       | Yes      | `docs`                        | Path to pre-built documentation directory |
+| `target`     | No       | `s3`                          | Deployment target: `s3` or `github`       |
+| `bucket`     | No       | `typeform-design-docs-vblxnu` | S3 bucket name                            |
+| `prefix`     | No       | Repository name               | S3 prefix for organization                |
+| `aws-region` | No       | `us-east-1`                   | AWS region for S3                         |
+
+## Output Parameters
+
+| Parameter  | Description                              |
+| ---------- | ---------------------------------------- |
+| `docs-url` | URL where the documentation was deployed |
+
+## Examples
+
+### Deploy to S3
+
+```yaml
+name: Deploy docs to S3
+on: [push]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build documentation
+        run: |
+          # Your build process here
+          npm run build-docs
+
+      - uses: Typeform/.github/shared-actions/docs@main
+        with:
+          path: "docs"
+          target: "s3"
+          prefix: "api-docs"
+```
+
+### Deploy to GitHub Pages
+
+```yaml
+name: Deploy docs to GitHub Pages
+on: [push]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build documentation
+        run: |
+          # Your build process here
+          npm run build-storybook -- --output-dir docs
+
+      - uses: Typeform/.github/shared-actions/docs@main
+        with:
+          path: "docs"
+          target: "github"
+```
+
+### Complete Workflow Example
+
+```yaml
+name: Build and deploy docs
+on: [push]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build documentation
+        run: npm run build-docs
+
+      - uses: Typeform/.github/shared-actions/docs@main
+        with:
+          path: "dist/docs"
+          target: "s3"
+          bucket: "my-custom-bucket"
+          prefix: "project-docs"
+```

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -1,5 +1,5 @@
 name: "Docs Action"
-description: "Upload and deploy documentation for projects to Typeform internal Docs Hub"
+description: "Upload and deploy documentation for projects to Typeform internal Docs"
 author: "Typeform"
 
 inputs:
@@ -114,7 +114,9 @@ runs:
           echo "Non-main branch with default prefix detected. Setting 1 month TTL on uploaded files..."
           # Calculate expiration date (30 days from now)
           EXPIRATION_DATE=$(date -d "+30 days" -u +"%Y-%m-%dT%H:%M:%SZ")
+          EXPIRATION_DATE_READABLE=$(date -d "+30 days" -u +"%B %d, %Y")
           echo "Expiration date: ${EXPIRATION_DATE}"
+          echo "expiration-date=${EXPIRATION_DATE_READABLE}" >> "$GITHUB_OUTPUT"
 
           # Sync to S3 with expiration metadata
           aws s3 sync "${{ inputs.path }}/" "${S3_PATH}" --delete --region "${{ inputs.aws-region }}" \
@@ -126,6 +128,7 @@ runs:
           else
             echo "Main branch detected. No TTL set on uploaded files."
           fi
+          echo "expiration-date=" >> "$GITHUB_OUTPUT"
           # Sync to S3 without expiration
           aws s3 sync "${{ inputs.path }}/" "${S3_PATH}" --delete --region "${{ inputs.aws-region }}"
         fi
@@ -154,6 +157,30 @@ runs:
         echo "Documentation deployed successfully!"
         echo "URL: ${DOCS_URL}"
         echo "docs-url=${DOCS_URL}" >> "$GITHUB_OUTPUT"
+
+    - name: Find existing PR comment
+      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      continue-on-error: true
+      with:
+        issue-number: ${{ github.event.number }}
+        body-includes: "📚 **Docs preview ready!**"
+
+    - name: Create or update PR comment
+      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+      uses: peter-evans/create-or-update-comment@v4
+      continue-on-error: true
+      with:
+        issue-number: ${{ github.event.number }}
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          📚 **Docs preview ready!**
+
+          View this PR's docs preview at: ${{ inputs.target == 's3' && steps.deploy-s3.outputs.docs-url || steps.set-github-pages-url.outputs.docs-url }}
+          ${{ inputs.target == 's3' && steps.deploy-s3.outputs.expiration-date && format('
+          ⚠️ The preview will be deleted on {0}', steps.deploy-s3.outputs.expiration-date) || '' }}
 
     - name: Set output URL
       id: deploy

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -134,7 +134,8 @@ runs:
         fi
 
         # Generate the documentation URL
-        DOCS_URL="https://${{ inputs.bucket }}.s3.amazonaws.com/${S3_PREFIX}/index.html"
+        DOCS_BASE_URL="https://docs.typeform.tf"
+        DOCS_URL="${DOCS_BASE_URL}/${S3_PREFIX}/index.html"
         echo "Documentation deployed successfully!"
         echo "URL: ${DOCS_URL}"
         echo "docs-url=${DOCS_URL}" >> "$GITHUB_OUTPUT"

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: "typeform-design-docs-vblxnu"
   prefix:
-    description: "S3 prefix to upload the docs (optional, defaults to the repository name)"
+    description: "S3 prefix to upload the docs (optional, defaults to <repo-name>/<branch>)"
     required: false
     default: ""
   aws-region:
@@ -85,11 +85,16 @@ runs:
       id: deploy-s3
       shell: bash
       run: |
-        # Determine S3 prefix
+        # Extract branch name from GitHub ref
+        BRANCH_NAME="${{ github.ref_name }}"
+
+        # Determine S3 prefix and whether it's custom
         if [ -n "${{ inputs.prefix }}" ]; then
           S3_PREFIX="${{ inputs.prefix }}"
+          CUSTOM_PREFIX=true
         else
-          S3_PREFIX="${{ github.event.repository.name }}"
+          S3_PREFIX="${{ github.event.repository.name }}/${BRANCH_NAME}"
+          CUSTOM_PREFIX=false
         fi
 
         S3_PATH="s3://${{ inputs.bucket }}/${S3_PREFIX}/"
@@ -98,11 +103,31 @@ runs:
         echo "S3 Bucket: ${{ inputs.bucket }}"
         echo "S3 Prefix: ${S3_PREFIX}"
         echo "Full S3 Path: ${S3_PATH}"
+        echo "Branch: ${BRANCH_NAME}"
+        echo "Custom prefix: ${CUSTOM_PREFIX}"
 
         echo "Using AWS CLI for S3 deployment..."
 
-        # Sync to S3
-        aws s3 sync "${{ inputs.path }}/" "${S3_PATH}" --delete --region "${{ inputs.aws-region }}"
+        # Determine if we need to set TTL (only for non-main branches with default prefix)
+        if [ "${BRANCH_NAME}" != "main" ] && [ "${CUSTOM_PREFIX}" = "false" ]; then
+          echo "Non-main branch with default prefix detected. Setting 1 month TTL on uploaded files..."
+          # Calculate expiration date (30 days from now)
+          EXPIRATION_DATE=$(date -d "+30 days" -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "Expiration date: ${EXPIRATION_DATE}"
+
+          # Sync to S3 with expiration metadata
+          aws s3 sync "${{ inputs.path }}/" "${S3_PATH}" --delete --region "${{ inputs.aws-region }}" \
+            --metadata "expiration=${EXPIRATION_DATE}" \
+            --metadata-directive REPLACE
+        else
+          if [ "${CUSTOM_PREFIX}" = "true" ]; then
+            echo "Custom prefix detected. No TTL applied."
+          else
+            echo "Main branch detected. No TTL set on uploaded files."
+          fi
+          # Sync to S3 without expiration
+          aws s3 sync "${{ inputs.path }}/" "${S3_PATH}" --delete --region "${{ inputs.aws-region }}"
+        fi
 
         # Generate the documentation URL
         DOCS_URL="https://${{ inputs.bucket }}.s3.amazonaws.com/${S3_PREFIX}/index.html"

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -57,23 +57,23 @@ runs:
           sudo ./aws/install
         fi
 
-    - name: Get Tools AWS account ID
+    - name: Get AWS account ID
       if: inputs.target == 's3'
-      id: tools_aws_account_id
+      id: aws_account_id
       shell: bash
-      run: echo "id=$(aws --region=us-east-1 ssm get-parameter --with-decryption --name /account/aws/tools/id --query Parameter.Value --output text)" >> $GITHUB_OUTPUT
+      run: echo "id=$(aws --region=us-east-1 ssm get-parameter --with-decryption --name /account/aws/dev/id --query Parameter.Value --output text)" >> $GITHUB_OUTPUT
 
-    - name: Build Tools IAM role ARN
+    - name: Build IAM role ARN
       if: inputs.target == 's3'
-      id: tools_aws_role_arn
+      id: aws_role_arn
       shell: bash
-      run: echo "arn=arn:aws:iam::${{ steps.tools_aws_account_id.outputs.id }}:role/gha.docs-action.us-east-1" >> $GITHUB_OUTPUT
+      run: echo "arn=arn:aws:iam::${{ steps.aws_account_id.outputs.id }}:role/gha.docs-action.us-east-1" >> $GITHUB_OUTPUT
 
     - name: Configure AWS credentials
       if: inputs.target == 's3'
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ steps.tools_aws_role_arn.outputs.arn }}
+        role-to-assume: ${{ steps.aws_role_arn.outputs.arn }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Deploy to S3

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -32,9 +32,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
     - name: Verify documentation directory
       shell: bash
       run: |

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -75,7 +75,6 @@ runs:
       with:
         role-to-assume: ${{ steps.tools_aws_role_arn.outputs.arn }}
         aws-region: ${{ inputs.aws-region }}
-        role-skip-session-tagging: true
 
     - name: Deploy to S3
       if: inputs.target == 's3'

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -1,0 +1,144 @@
+name: "Docs Action"
+description: "Upload and deploy documentation for projects to Typeform internal Docs Hub"
+author: "Typeform"
+
+inputs:
+  path:
+    description: "Path to the pre-built documentation directory"
+    required: true
+    default: "docs"
+  target:
+    description: "Deployment target: 's3' for S3 bucket or 'github' for GitHub Pages"
+    required: false
+    default: "s3"
+  bucket:
+    description: "S3 bucket to upload the docs (optional, internal shared bucket is used by default)"
+    required: false
+    default: "typeform-design-docs-vblxnu"
+  prefix:
+    description: "S3 prefix to upload the docs (optional, defaults to the repository name)"
+    required: false
+    default: ""
+  aws-region:
+    description: "AWS region for S3 deployment"
+    required: false
+    default: "us-east-1"
+
+outputs:
+  docs-url:
+    description: "URL where the documentation was deployed"
+    value: ${{ steps.deploy.outputs.docs-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Verify documentation directory
+      shell: bash
+      run: |
+        if [ ! -d "${{ inputs.path }}" ]; then
+          echo "Error: Documentation directory '${{ inputs.path }}' does not exist"
+          exit 1
+        fi
+        if [ ! "$(ls -A "${{ inputs.path }}")" ]; then
+          echo "Error: Documentation directory '${{ inputs.path }}' is empty"
+          exit 1
+        fi
+        echo "Documentation directory verified: ${{ inputs.path }}"
+        ls -la ${{ inputs.path }}
+
+    - name: Install AWS CLI
+      if: inputs.target == 's3'
+      shell: bash
+      run: |
+        if ! command -v aws &> /dev/null; then
+          echo "Installing AWS CLI..."
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+        fi
+
+    - name: Get Tools AWS account ID
+      if: inputs.target == 's3'
+      id: tools_aws_account_id
+      shell: bash
+      run: echo "id=$(aws --region=us-east-1 ssm get-parameter --with-decryption --name /account/aws/tools/id --query Parameter.Value --output text)" >> $GITHUB_OUTPUT
+
+    - name: Build Tools IAM role ARN
+      if: inputs.target == 's3'
+      id: tools_aws_role_arn
+      shell: bash
+      run: echo "arn=arn:aws:iam::${{ steps.tools_aws_account_id.outputs.id }}:role/gha.docs-action.us-east-1" >> $GITHUB_OUTPUT
+
+    - name: Configure AWS credentials
+      if: inputs.target == 's3'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ steps.tools_aws_role_arn.outputs.arn }}
+        role-session-name: docs-action-${{ github.run_id }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Deploy to S3
+      if: inputs.target == 's3'
+      id: deploy-s3
+      shell: bash
+      run: |
+        # Determine S3 prefix
+        if [ -n "${{ inputs.prefix }}" ]; then
+          S3_PREFIX="${{ inputs.prefix }}"
+        else
+          S3_PREFIX="${{ github.event.repository.name }}"
+        fi
+
+        S3_PATH="s3://${{ inputs.bucket }}/${S3_PREFIX}/"
+
+        echo "Deploying to S3..."
+        echo "S3 Bucket: ${{ inputs.bucket }}"
+        echo "S3 Prefix: ${S3_PREFIX}"
+        echo "Full S3 Path: ${S3_PATH}"
+
+        echo "Using AWS CLI for S3 deployment..."
+
+        # Sync to S3
+        aws s3 sync "${{ inputs.path }}/" "${S3_PATH}" --delete --region "${{ inputs.aws-region }}"
+
+        # Generate the documentation URL
+        DOCS_URL="https://${{ inputs.bucket }}.s3.amazonaws.com/${S3_PREFIX}/index.html"
+        echo "Documentation deployed successfully!"
+        echo "URL: ${DOCS_URL}"
+        echo "docs-url=${DOCS_URL}" >> "$GITHUB_OUTPUT"
+
+    - name: Deploy to GitHub Pages
+      if: inputs.target == 'github'
+      id: deploy-github
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages
+        folder: ${{ inputs.path }}
+        clean: true
+
+    - name: Set GitHub Pages output URL
+      if: inputs.target == 'github'
+      id: set-github-pages-url
+      shell: bash
+      run: |
+        DOCS_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+        echo "Documentation deployed successfully!"
+        echo "URL: ${DOCS_URL}"
+        echo "docs-url=${DOCS_URL}" >> "$GITHUB_OUTPUT"
+
+    - name: Set output URL
+      id: deploy
+      shell: bash
+      run: |
+        if [ "${{ inputs.target }}" = "s3" ]; then
+          echo "docs-url=${{ steps.deploy-s3.outputs.docs-url }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "docs-url=${{ steps.set-github-pages-url.outputs.docs-url }}" >> "$GITHUB_OUTPUT"
+        fi
+
+branding:
+  icon: "book-open"
+  color: "blue"

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -82,7 +82,12 @@ runs:
       shell: bash
       run: |
         # Extract branch name from GitHub ref
-        BRANCH_NAME="${{ github.ref_name }}"
+        # For pull requests, use head_ref (source branch), otherwise use ref_name
+        if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          BRANCH_NAME="${{ github.head_ref }}"
+        else
+          BRANCH_NAME="${{ github.ref_name }}"
+        fi
 
         # Determine S3 prefix and whether it's custom
         if [ -n "${{ inputs.prefix }}" ]; then

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -75,6 +75,7 @@ runs:
       with:
         role-to-assume: ${{ steps.tools_aws_role_arn.outputs.arn }}
         aws-region: ${{ inputs.aws-region }}
+        role-skip-session-tagging: true
 
     - name: Deploy to S3
       if: inputs.target == 's3'

--- a/shared-actions/docs/action.yml
+++ b/shared-actions/docs/action.yml
@@ -74,7 +74,6 @@ runs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ steps.tools_aws_role_arn.outputs.arn }}
-        role-session-name: docs-action-${{ github.run_id }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Deploy to S3


### PR DESCRIPTION
Experimental shared GitHub Action to deploy internal docs.

Supports GitHub Pages for compatibility with current workflows, as well as the new internal S3 bucket.

See the [Docs Hub](https://www.notion.so/typeform/Replace-GitHub-Pages-documentation-with-docs-typeform-tf-18223dfc4c008090a1cbc2a281334fc2) proposal.