### PR TITLE
Fix Yarn not found in CI by installing it manually in shared workflow

### DIFF
--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install Yarn
+        run: npm install -g yarn@1.22.22
+
       - name: Set GitHub packages registry
         run: |
           npm config set '//npm.pkg.github.com/:_authToken' ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This PR updates the Generate persisted operations shared workflow to explicitly install the required Yarn version (1.22.22) via npm instead of relying on asdf and .tool-versions.

🔧 Changes:
	•	Added npm install -g yarn@1.22.22 after setting up Node.js in the workflow.

🐛 Problem:

Workflows were failing on some repositories with the following error:

> No preset version installed for command yarn
> Please install a version by running:
> asdf install yarn 1.22.22

This happened because .tool-versions was present in some repos, triggering asdf version management, but the required Yarn version wasn’t installed on the CI runner.

✅ Solution:

Installing Yarn directly with npm ensures the correct version is available regardless of .tool-versions or asdf setup.

This change avoids inconsistent behavior across repositories and ensures the workflow runs reliably everywhere.