### PR TITLE
fix(PLT-1044): Yarn .npmrc Interpolation Error in CI

### DIFF
--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -10,6 +10,7 @@ jobs:
   update-allow-list:
     runs-on: [self-hosted, ci-universal]
     env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
       GRAPHQL_ENDPOINTS: |
         https://graphqlbff.staging.internal.tfdev.typeform.tf
         https://graphqlbff.tfprod.internal.typeform.tf


### PR DESCRIPTION
**What’s Changed**

Added GH_TOKEN to the env: block of the update-allow-list job in the “Generate persisted operations” GitHub Actions workflow.

**Why**
	•	Yarn was failing with the error:
	`Error: Failed to replace env in config: ${GH_TOKEN}`