### PR TITLE
feat(deep-purple-checks): allow to pass app name explicitly

### DIFF
--- a/.github/workflows/deep-purple-checks.yml
+++ b/.github/workflows/deep-purple-checks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, ci-universal]
 
     env:
-      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:dev-16266907570
+      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:latest
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/deep-purple-checks.yml
+++ b/.github/workflows/deep-purple-checks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, ci-universal]
 
     env:
-      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:dev-16197627412
+      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:dev-16263128562
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/deep-purple-checks.yml
+++ b/.github/workflows/deep-purple-checks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, ci-universal]
 
     env:
-      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:dev-16263128562
+      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:dev-16266907570
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/deep-purple-checks.yml
+++ b/.github/workflows/deep-purple-checks.yml
@@ -9,6 +9,11 @@ on:
         required: true
       STAGING_PERSONAL_ACCESS_TOKEN:
         required: true
+    inputs:
+      app:
+        type: string
+        default: ""
+        required: false
 
 jobs:
   run-deep-purple-tests:
@@ -16,7 +21,7 @@ jobs:
     runs-on: [self-hosted, ci-universal]
 
     env:
-      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:latest
+      DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:dev-16197627412
 
     steps:
       - name: Check out Git repository
@@ -24,7 +29,12 @@ jobs:
 
       - name: Extract app name from package.json
         run: |
-          echo "APP_NAME=$(jq -r '.name' package.json | sed 's/@typeform\///')" >> $GITHUB_ENV
+          APP="${{ inputs.app }}"
+          if [ -z "${APP}" ]; then
+            echo "APP_NAME=$(jq -r '.name' package.json | sed 's/@typeform\///')" >> $GITHUB_ENV
+          else
+            echo "APP_NAME=${APP}" >> $GITHUB_ENV
+          fi
 
       - name: Print extracted app name
         run: echo "Extracted APP_NAME is ${{ env.APP_NAME }}"


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-2115

Allow passing in the app name for deep-purple-checks Github workflow explicitly.

Not all repositories define the frontend app name in the root package.json. This is for example the case for `bob-the-builder`, our builder frontend app. 

Passing the app name explicitly is more obvious and less error-prone than trying to find the correct app name in multiple package.json files.