### PR TITLE
feat(comment-deploy-link): include service name in comment

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -77,7 +77,7 @@ jobs:
         id: find-comment
         with:
           issue-number: ${{ github.event.number }}
-          body-includes: '🚀 Deploy this version in'
+          body-includes: "🚀 Deploy this version of `${{ inputs.service }}` in"
 
       - name: Create Comment
         uses: peter-evans/create-or-update-comment@v4
@@ -86,8 +86,8 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            🎉 Version `${{ inputs.version }}` created, hooray!
-            🚀 Deploy this version in an **ephemeral environment** with `--reference`:
+            🎉 Version `${{ inputs.version }}` of service `${{ inputs.service }}` created, hooray!
+            🚀 Deploy this version of `${{ inputs.service }}`in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
 
       - name: Update Comment
@@ -97,8 +97,8 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            🎉 Version `${{ inputs.version }}` created, hooray!
-            🚀 Deploy this version in an **ephemeral environment** with `--reference`:
+            🎉 Version `${{ inputs.version }}` of service `${{ inputs.service }}` created, hooray!
+            🚀 Deploy this version of `${{ inputs.service }}`in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace


### PR DESCRIPTION
This PR includes the service name in the comment. This enables us to use distinct comments for each service in a monorepo context.

Example CI configuration:
```yaml
  comment-deploy-link:
    name: Comment deploy link
    if: github.event_name == 'pull_request' && !contains('Bot', github.event.pull_request.user.type)
    needs: [ test-and-build ]
    strategy:
      matrix:
        service: ${{ fromJSON(needs.test-and-build.outputs.affected-services) }}
        version: [ '${{ needs.test-and-build.outputs.image-version }}' ]
    uses: Typeform/.github/.github/workflows/comment-deploy-link.yaml@v1
    with:
      base-url: 'https://jenkins.tools.typeform.tf/job/deploy-ephemeral/job/deploy-ephemeral/parambuild/'
      service: ${{ matrix.service }}
      version: ${{ matrix.version }}
      update-comment: true
```