### PR TITLE
fix(comment-deploy-link): typo

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -12,7 +12,7 @@ on:
       version:
         type: string
         required: true
-      git_sha:
+      git-sha:
         type: string
         required: false
         default: ${{ github.event.pull_request.head.sha  }}
@@ -90,7 +90,7 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            🎉 Version `${{ inputs.version }}` of service `${{ inputs.service }}` from commit ${{ inputs.git_sha }} created, hooray!
+            🎉 Version `${{ inputs.version }}` of service `${{ inputs.service }}` from commit ${{ inputs.git-sha }} created, hooray!
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
 
@@ -101,7 +101,7 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            🎉 Version `${{ inputs.version }}` of service `${{ inputs.service }}` from commit ${{ inputs.git_sha }} created, hooray!
+            🎉 Version `${{ inputs.version }}` of service `${{ inputs.service }}` from commit ${{ inputs.git-sha }} created, hooray!
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
### Fixed

Fixes a typo that causes the search query to miss previous comments.

### Added

Git SHA included in the message, so that the reader can quickly verify which commit is the service version built from. Can be overridden via optional `git-sha` parameter.

### Testing

See https://github.com/Typeform/.github/pull/137#issuecomment-3083572714