### PR TITLE
fix(go-lint-workflow): bump golangci-lint

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -26,7 +26,7 @@ on:
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.64.4"
+        default: "v1.64.5"
 
 jobs:
   lint:


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-2157

Bump the golangci-lint default version, because it was updated in the golang-builder image: https://github.com/Typeform/golang-builder/pull/127