### PR TITLE
fix: bump default golangci-lint

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -26,7 +26,7 @@ on:
       golangci-lint-version:
         type: string
         required: false
-        default: "v1.64.4"
+        default: "v1.64.8"
 
 jobs:
   lint:


### PR DESCRIPTION
Bumping the default golangci-lint to `1.64.8`, https://github.com/Typeform/golang-builder/pull/130