### PR TITLE
feat(image-multiarch): allow to configure self-hosted runner

### DIFF
--- a/.github/workflows/ci-standard-checks-workflow.yaml
+++ b/.github/workflows/ci-standard-checks-workflow.yaml
@@ -21,8 +21,7 @@ on:
 
 jobs:
   ci-standard-checks:
-    runs-on:
-      - ubuntu-latest
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Check Out Source Code
         uses: actions/checkout@v4

--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -20,15 +20,11 @@ on:
         type: boolean
         required: false
         default: false
-      runs-on:
-        type: string
-        required: false
-        default: fear-ephemeral
 
 jobs:
   comment:
     name: Comment link
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
 
     steps:
       - name: Get deploy link(s)

--- a/.github/workflows/deep-purple-checks.yml
+++ b/.github/workflows/deep-purple-checks.yml
@@ -14,11 +14,16 @@ on:
         type: string
         default: ""
         required: false
+      runner:
+        description: "Self-hosted GHA runner"
+        type: string
+        required: false
+        default: "ci-universal"
 
 jobs:
   run-deep-purple-tests:
     name: Run Deep Purple Tests Against Changes
-    runs-on: [self-hosted, ci-universal]
+    runs-on: [self-hosted, "${{ inputs.runner }}"]
 
     env:
       DOCKER_IMAGE: 567716553783.dkr.ecr.us-east-1.amazonaws.com/deep-purple:latest

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -32,7 +32,7 @@ jobs:
   lint:
     if: ${{ !contains('Bot', github.event.pull_request.user.type) }}
     name: Run linter
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/graphql-generate-persisted-operations.yml
+++ b/.github/workflows/graphql-generate-persisted-operations.yml
@@ -2,13 +2,19 @@ name: "Generate persisted operations"
 
 on:
   workflow_call:
+    inputs:
+      runner:
+        description: "Self-hosted GHA runner"
+        type: string
+        required: false
+        default: "ci-universal"
     secrets:
       GH_TOKEN:
         required: true
 
 jobs:
   update-allow-list:
-    runs-on: [self-hosted, ci-universal]
+    runs-on: [self-hosted, "${{ inputs.runner }}"]
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       GRAPHQL_ENDPOINTS: |

--- a/.github/workflows/image-multiarch.yaml
+++ b/.github/workflows/image-multiarch.yaml
@@ -45,13 +45,18 @@ on:
         description: "Image labels"
         type: string
         required: false
+      runner:
+        description: "Self-hosted GHA runner"
+        type: string
+        required: false
+        default: "ci-base"
 env:
   VERSION_PREFIX: ''
   VERSION_LATEST: latest
 jobs:
   build:
     name: Build and push image
-    runs-on: [ self-hosted, ci-base]
+    runs-on: [ self-hosted, "${{ inputs.runner }}" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-2282

Allow to configure the self-hosted runner name for the shared workflows.
Defaults to the originally harcoded values.

This allows per-repository runners, without breaking all other repositories' actions at once.