### PR TITLE
feat: dynamic golangci-lint versions and configuration

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -34,7 +34,7 @@ on:
       golangci-lint-config-repo-ref:
         type: string
         required: false
-        default: "1.14.12"
+        default: "1.14.13"
       golangci-lint-config-repo-path:
         type: string
         required: false

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -81,11 +81,11 @@ jobs:
           uses: golangci/golangci-lint-action@${{ inputs.golangci-lint-action-version }}
           with: |
             {
-              "version": ${{ inputs.golangci-lint-version }},
-              "only-new-issues": ${{ inputs.only-new-issues }},
-              "working-directory": "${{ inputs.working-directory }}",
+              "version": ${{ toJSON(inputs.golangci-lint-version) }},
+              "only-new-issues": ${{ toJSON(inputs.only-new-issues) }},
+              "working-directory": "${{ toJSON(inputs.working-directory) }}",
               "verify": false,
-              "args": "--config ${{ github.workspace }}/${{ inputs.golangci-lint-config-repo-path }}/config/golangci.yaml --timeout=${{ inputs.timeout }}" 
+              "args": ${{ toJSON(format('--config {0}/{1}/config/golangci.yaml --timeout={2}', github.workspace, inputs.golangci-lint-config-repo-path, inputs.timeout)) }}
             }
 
       - name: Comment body

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -84,7 +84,7 @@ jobs:
             {
               "version": ${{ toJSON(inputs.golangci-lint-version) }},
               "only-new-issues": ${{ toJSON(inputs.only-new-issues) }},
-              "working-directory": "${{ toJSON(inputs.working-directory) }}",
+              "working-directory": ${{ toJSON(inputs.working-directory) }},
               "verify": false,
               "args": ${{ toJSON(format('--config {0}/{1}/config/golangci.yaml --timeout={2}', github.workspace, inputs.golangci-lint-config-repo-path, inputs.timeout)) }}
             }

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -76,6 +76,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
+        id: runlint
         uses: jenseng/dynamic-uses@v1
         with:
           uses: golangci/golangci-lint-action@${{ inputs.golangci-lint-action-version }}
@@ -83,7 +84,7 @@ jobs:
             {
               "version": ${{ toJSON(inputs.golangci-lint-version) }},
               "only-new-issues": ${{ toJSON(inputs.only-new-issues) }},
-              "working-directory": ${{ toJSON(inputs.working-directory) }},
+              "working-directory": "${{ toJSON(inputs.working-directory) }}",
               "verify": false,
               "args": ${{ toJSON(format('--config {0}/{1}/config/golangci.yaml --timeout={2}', github.workspace, inputs.golangci-lint-config-repo-path, inputs.timeout)) }}
             }
@@ -92,7 +93,11 @@ jobs:
         id: comment-body-content
         if: ${{ !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/main') && (success() || failure()) }}
         run: |
-          echo "${{ fromJSON(steps.golangci-lint.outputs) }}"
+          if [[ "${{ steps.runlint.outcome }}" == "success" ]]; then
+            echo "results=$(echo ":tada::tada: **Congratulations! Your code seems to be really nice!** :tada::tada:")" >> $GITHUB_OUTPUT
+          else
+            echo "results=$(echo ":rotating_light::rotating_light: **There are linting issues, check the \`Files changed\` tab for more info** :rotating_light::rotating_light:")" >> $GITHUB_OUTPUT
+          fi
 
       - name: Find previous lint comment
         if: ${{ !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/main') && (success() || failure()) }}

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -34,7 +34,7 @@ on:
       golangci-lint-config-repo-ref:
         type: string
         required: false
-        default: "1.14.13"
+        default: "1.15.0"
       golangci-lint-config-repo-path:
         type: string
         required: false

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -27,6 +27,10 @@ on:
         type: string
         required: false
         default: "v1.64.8"
+      golangci-lint-action-version:
+        type: string
+        required: false
+        default: "v6"
       golangci-lint-config-repo:
         type: string
         required: false
@@ -72,14 +76,10 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        id: golangci-lint
+        uses: jenseng/dynamic-uses@v1
         with:
-          version: ${{ inputs.golangci-lint-version }}
-          only-new-issues: ${{ inputs.only-new-issues }}
-          working-directory: ${{ inputs.working-directory }}
-          verify: false # no need to verify, we know golang-builder has a valid config
-          args: --config ${{ github.workspace }}/${{ inputs.golangci-lint-config-repo-path }}/config/golangci.yaml --timeout=${{ inputs.timeout }}
+          uses: golangci/golangci-lint-action@${{ inputs.golangci-lint-action-version }}
+          with: '{ "version": ${{ inputs.golangci-lint-version }}, "only-new-issues": ${{ inputs.only-new-issues }}, "working-directory": "${{ inputs.working-directory }}", "verify": false, "args": "--config ${{ github.workspace }}/${{ inputs.golangci-lint-config-repo-path }}/config/golangci.yaml --timeout=${{ inputs.timeout }}" }'
 
       - name: Comment body
         id: comment-body-content

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -92,7 +92,7 @@ jobs:
         id: comment-body-content
         if: ${{ !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/main') && (success() || failure()) }}
         run: |
-          if [[ "${{ steps.golangci-lint.conclusion }}" == "success" ]]; then
+          if [[ "${{ fromJSON(steps.golangci-lint).conclusion }}" == "success" ]]; then
             echo "results=$(echo ":tada::tada: **Congratulations! Your code seems to be really nice!** :tada::tada:")" >> $GITHUB_OUTPUT
           else
             echo "results=$(echo ":rotating_light::rotating_light: **There are linting issues, check the \`Files changed\` tab for more info** :rotating_light::rotating_light:")" >> $GITHUB_OUTPUT

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -83,7 +83,7 @@ jobs:
             {
               "version": ${{ toJSON(inputs.golangci-lint-version) }},
               "only-new-issues": ${{ toJSON(inputs.only-new-issues) }},
-              "working-directory": "${{ toJSON(inputs.working-directory) }}",
+              "working-directory": ${{ toJSON(inputs.working-directory) }},
               "verify": false,
               "args": ${{ toJSON(format('--config {0}/{1}/config/golangci.yaml --timeout={2}', github.workspace, inputs.golangci-lint-config-repo-path, inputs.timeout)) }}
             }

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -92,7 +92,8 @@ jobs:
         id: comment-body-content
         if: ${{ !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/main') && (success() || failure()) }}
         run: |
-          if [[ "${{ fromJSON(steps.golangci-lint).conclusion }}" == "success" ]]; then
+          echo "${{ fromJSON(steps.golangci-lint.outputs) }}"
+          if [[ "${{ fromJSON(steps.golangci-lint.outputs).conclusion }}" == "success" ]]; then
             echo "results=$(echo ":tada::tada: **Congratulations! Your code seems to be really nice!** :tada::tada:")" >> $GITHUB_OUTPUT
           else
             echo "results=$(echo ":rotating_light::rotating_light: **There are linting issues, check the \`Files changed\` tab for more info** :rotating_light::rotating_light:")" >> $GITHUB_OUTPUT

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -79,7 +79,14 @@ jobs:
         uses: jenseng/dynamic-uses@v1
         with:
           uses: golangci/golangci-lint-action@${{ inputs.golangci-lint-action-version }}
-          with: '{ "version": ${{ inputs.golangci-lint-version }}, "only-new-issues": ${{ inputs.only-new-issues }}, "working-directory": "${{ inputs.working-directory }}", "verify": false, "args": "--config ${{ github.workspace }}/${{ inputs.golangci-lint-config-repo-path }}/config/golangci.yaml --timeout=${{ inputs.timeout }}" }'
+          with: |
+            {
+              "version": ${{ inputs.golangci-lint-version }},
+              "only-new-issues": ${{ inputs.only-new-issues }},
+              "working-directory": "${{ inputs.working-directory }}",
+              "verify": false,
+              "args": "--config ${{ github.workspace }}/${{ inputs.golangci-lint-config-repo-path }}/config/golangci.yaml --timeout=${{ inputs.timeout }}" 
+            }
 
       - name: Comment body
         id: comment-body-content

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -93,11 +93,6 @@ jobs:
         if: ${{ !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/main') && (success() || failure()) }}
         run: |
           echo "${{ fromJSON(steps.golangci-lint.outputs) }}"
-          if [[ "${{ fromJSON(steps.golangci-lint.outputs).conclusion }}" == "success" ]]; then
-            echo "results=$(echo ":tada::tada: **Congratulations! Your code seems to be really nice!** :tada::tada:")" >> $GITHUB_OUTPUT
-          else
-            echo "results=$(echo ":rotating_light::rotating_light: **There are linting issues, check the \`Files changed\` tab for more info** :rotating_light::rotating_light:")" >> $GITHUB_OUTPUT
-          fi
 
       - name: Find previous lint comment
         if: ${{ !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/main') && (success() || failure()) }}

--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -27,6 +27,18 @@ on:
         type: string
         required: false
         default: "v1.64.8"
+      golangci-lint-config-repo:
+        type: string
+        required: false
+        default: "Typeform/golang-builder"
+      golangci-lint-config-repo-ref:
+        type: string
+        required: false
+        default: "1.14.12"
+      golangci-lint-config-repo-path:
+        type: string
+        required: false
+        default: "lint-config"
 
 jobs:
   lint:
@@ -41,9 +53,9 @@ jobs:
       - name: Check out repository containing linter config
         uses: actions/checkout@v5
         with:
-          repository: Typeform/golang-builder
-          ref: main
-          path: lint-config
+          repository: ${{ inputs.golangci-lint-config-repo }}
+          ref: ${{ inputs.golangci-lint-config-repo-ref }}
+          path: ${{ inputs.golangci-lint-config-repo-path }}
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Configure git for private modules
@@ -67,7 +79,7 @@ jobs:
           only-new-issues: ${{ inputs.only-new-issues }}
           working-directory: ${{ inputs.working-directory }}
           verify: false # no need to verify, we know golang-builder has a valid config
-          args: --config ${{ github.workspace }}/lint-config/config/golangci.yaml --timeout=${{ inputs.timeout }}
+          args: --config ${{ github.workspace }}/${{ inputs.golangci-lint-config-repo-path }}/config/golangci.yaml --timeout=${{ inputs.timeout }}
 
       - name: Comment body
         id: comment-body-content


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-2300

Make the configuration file location of golangci-lint (`golangci.yaml`) configurable.

This is a preparation for the move to golangci-lint v2. The configuration files between v1 and v2 are not compatible, which means that once we move the golangci-lint executable to `2.x`, a single location for the file is not sufficient, as some repos will be on v1, and others on v2.

The defaults are the hardcoded values from today, with the exception of `ref`, which is set to `1.15.0` (latest tag with a `v1` configuration file).

Tested for backwards compatibility: https://github.com/Typeform/event-dispatcher/actions/runs/17552732900/job/49848910468?pr=605