### PR TITLE
fix: revert golangci-lint action to v6

### DIFF
--- a/.github/workflows/go-lint-workflow.yaml
+++ b/.github/workflows/go-lint-workflow.yaml
@@ -60,7 +60,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v6
         id: golangci-lint
         with:
           version: ${{ inputs.golangci-lint-version }}


### PR DESCRIPTION
 revert golangci-lint action to v6 as from v7, only golangci-lint v2 is supported