### PR TITLE
Add Playwright visual regression test support

### DIFF
--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -649,7 +649,8 @@ jobs:
     
     steps:
       - name: Run Playwright Visual Tests
-        uses: Typeform/.github/shared-actions/run-playwright-visual@v1
+        # TODO: Change back to @v1 after this PR is merged and v1 tag is updated
+        uses: Typeform/.github/shared-actions/run-playwright-visual@add-playwright-visual-tests
         with:
           node-version: ${{ inputs.node-version }}
           use-asdf: ${{ inputs.use-asdf }}

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -649,8 +649,7 @@ jobs:
     
     steps:
       - name: Run Playwright Visual Tests
-        # TODO: Change back to @v1 after this PR is merged and v1 tag is updated
-        uses: Typeform/.github/shared-actions/run-playwright-visual@add-playwright-visual-tests
+        uses: Typeform/.github/shared-actions/run-playwright-visual@v1
         with:
           node-version: ${{ inputs.node-version }}
           use-asdf: ${{ inputs.use-asdf }}

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -149,6 +149,15 @@ on:
         type: string
         default: 'http://localhost:9000'
       
+      run-playwright-visual:
+        description: 'Run Playwright visual regression tests'
+        type: boolean
+        default: false
+      playwright-visual-command:
+        description: 'Playwright visual test command'
+        type: string
+        default: 'yarn test:visual'
+      
       run-cypress-visual:
         description: 'Run Cypress visual regression tests'
         type: boolean
@@ -630,7 +639,38 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
   
-  # Job 9: Cypress Visual Tests
+  # Job 9: Playwright Visual Tests
+  playwright-visual:
+    name: 🎨 Playwright Visual
+    if: inputs.run-playwright-visual
+    needs: build
+    runs-on: ${{ fromJSON(inputs.e2e-runner) }}
+    timeout-minutes: ${{ inputs.integration-timeout }}
+    
+    steps:
+      - name: Run Playwright Visual Tests
+        uses: Typeform/.github/shared-actions/run-playwright-visual@v1
+        with:
+          node-version: ${{ inputs.node-version }}
+          use-asdf: ${{ inputs.use-asdf }}
+          cache-mode: ${{ inputs.cache-mode }}
+          disable-restore-keys: ${{ inputs.disable-restore-keys }}
+          jarvis-branch: ${{ inputs.jarvis-branch }}
+          pre-test-command: ${{ inputs.pre-test-command }}
+          test-command: ${{ inputs.playwright-visual-command }}
+          build-artifact-name: ${{ needs.build.outputs.artifact-name }}
+          build-artifact-download-path: ${{ inputs.build-artifact-download-path || inputs.build-output-dir }}
+          turbo-scm-base: ${{ inputs.turbo-scm-base }}
+          vrt-branch-name: ${{ github.head_ref || github.ref_name }}
+          vrt-build-id: ${{ github.sha }}
+          artifact-name: 'playwright-visual-results-${{ github.run_id }}'
+          artifact-retention-days: '7'
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          VRT_APIURL: ${{ secrets.VRT_APIURL }}
+          VRT_APIKEY: ${{ secrets.VRT_APIKEY }}
+          VRT_PROJECT: ${{ secrets.VRT_PROJECT }}
+  
+  # Job 10: Cypress Visual Tests
   cypress-visual:
     name: 🎨 Cypress Visual
     if: inputs.run-cypress-visual

--- a/shared-actions/run-playwright-visual/action.yml
+++ b/shared-actions/run-playwright-visual/action.yml
@@ -1,0 +1,149 @@
+name: 'Run Playwright Visual Regression Tests'
+description: 'Execute Playwright visual regression tests with VRT integration and artifact upload'
+
+inputs:
+  # Node & Jarvis configuration
+  node-version:
+    description: 'Node.js version (ignored if use-asdf is true)'
+    required: false
+    default: '20'
+  use-asdf:
+    description: 'Use asdf-vm for version management'
+    required: false
+    default: 'false'
+  cache-mode:
+    description: 'Cache strategy: full, node_modules-only, or yarn-cache-only'
+    required: false
+    default: 'full'
+  disable-restore-keys:
+    description: 'Disable restore-keys to avoid restoring stale caches'
+    required: false
+    default: 'false'
+  jarvis-branch:
+    description: 'Jarvis branch to use (empty = npm version)'
+    required: false
+    default: ''
+
+  # Pre-test setup
+  pre-test-command:
+    description: 'Command to run before tests (e.g., GraphQL codegen)'
+    required: false
+    default: ''
+
+  # Playwright test configuration
+  test-command:
+    description: 'Playwright visual test command'
+    required: false
+    default: 'yarn test:visual'
+
+  # Build artifact configuration
+  build-artifact-name:
+    description: 'Build artifact name to download'
+    required: false
+    default: ''
+  build-artifact-download-path:
+    description: 'Directory to download build artifacts into'
+    required: false
+    default: 'dist'
+
+  # Turbo monorepo configuration
+  turbo-scm-base:
+    description: 'Git SHA for Turbo SCM base comparison'
+    required: false
+    default: ''
+
+  # VRT configuration
+  vrt-branch-name:
+    description: 'Branch name for VRT comparison (defaults to github.head_ref or github.ref_name)'
+    required: false
+    default: ''
+  vrt-build-id:
+    description: 'Build ID for VRT (defaults to github.sha)'
+    required: false
+    default: ''
+  # Artifact configuration
+  artifact-name:
+    description: 'Name for uploaded test results artifact'
+    required: false
+    default: 'playwright-visual-results'
+  artifact-retention-days:
+    description: 'Days to retain test result artifacts'
+    required: false
+    default: '7'
+
+  # Secrets (passed as inputs since composite actions cannot access secrets directly)
+  GH_TOKEN:
+    description: 'GitHub token for authentication'
+    required: true
+  VRT_APIURL:
+    description: 'Visual Regression Tracker API URL'
+    required: false
+    default: ''
+  VRT_APIKEY:
+    description: 'Visual Regression Tracker API key'
+    required: false
+    default: ''
+  VRT_PROJECT:
+    description: 'Visual Regression Tracker project name'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v6
+
+    - name: Setup Node with Cache
+      uses: Typeform/.github/shared-actions/setup-node-with-cache@v1
+      with:
+        node-version: ${{ inputs.node-version }}
+        use-asdf: ${{ inputs.use-asdf }}
+        cache-mode: ${{ inputs.cache-mode }}
+        disable-restore-keys: ${{ inputs.disable-restore-keys }}
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
+
+    - name: Setup Jarvis
+      uses: Typeform/.github/shared-actions/setup-jarvis@v1
+      with:
+        jarvis-branch: ${{ inputs.jarvis-branch }}
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
+
+    - name: Setup Playwright
+      uses: Typeform/.github/shared-actions/setup-playwright@v1
+
+    - name: Download Build Artifacts
+      if: inputs.build-artifact-name != ''
+      uses: Typeform/.github/shared-actions/download-build-artifacts@v1
+      with:
+        artifact-name: ${{ inputs.build-artifact-name }}
+        output-dir: ${{ inputs.build-artifact-download-path }}
+
+    - name: Run pre-test command
+      if: inputs.pre-test-command != ''
+      shell: bash
+      run: ${{ inputs.pre-test-command }}
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
+        TURBO_SCM_BASE: ${{ inputs.turbo-scm-base }}
+
+    - name: Run Playwright visual tests
+      shell: bash
+      run: ${{ inputs.test-command }}
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
+        TURBO_SCM_BASE: ${{ inputs.turbo-scm-base }}
+        VRT_APIURL: ${{ inputs.VRT_APIURL }}
+        VRT_APIKEY: ${{ inputs.VRT_APIKEY }}
+        VRT_PROJECT: ${{ inputs.VRT_PROJECT }}
+        VRT_BRANCHNAME: ${{ inputs.vrt-branch-name }}
+        VRT_CIBUILDID: ${{ inputs.vrt-build-id }}
+
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: playwright-report/
+        retention-days: ${{ fromJSON(inputs.artifact-retention-days) }}


### PR DESCRIPTION
The frontend PR workflow only supports Cypress for visual regression tests. Teams that migrated to Playwright have no way to run visual tests through the shared workflow.

Add a run-playwright-visual shared action that mirrors the existing run-cypress-visual action but uses setup-playwright and runs the test command directly (Playwright handles its own webServer config, so no start-command/wait-on is needed). Upload playwright-report/ as the artifact instead of cypress/screenshots/ and cypress/videos/.

Add a playwright-visual job to the frontend PR workflow, gated behind a run-playwright-visual boolean input, with a configurable command defaulting to yarn test:visual. The job passes the same VRT secrets as the Cypress visual job for consistency.