### PR TITLE
fix: forward cache-mode and disable-restore-keys to Cypress composite actions

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -480,6 +480,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           use-asdf: ${{ inputs.use-asdf }}
+          cache-mode: ${{ inputs.cache-mode }}
+          disable-restore-keys: ${{ inputs.disable-restore-keys }}
           jarvis-branch: ${{ inputs.jarvis-branch }}
           pre-test-command: ${{ inputs.pre-test-command }}
           test-command: ${{ inputs.cypress-functional-command }}
@@ -504,6 +506,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           use-asdf: ${{ inputs.use-asdf }}
+          cache-mode: ${{ inputs.cache-mode }}
+          disable-restore-keys: ${{ inputs.disable-restore-keys }}
           jarvis-branch: ${{ inputs.jarvis-branch }}
           pre-test-command: ${{ inputs.pre-test-command }}
           test-command: ${{ inputs.cypress-visual-command }}

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -629,6 +629,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           use-asdf: ${{ inputs.use-asdf }}
+          cache-mode: ${{ inputs.cache-mode }}
+          disable-restore-keys: ${{ inputs.disable-restore-keys }}
           jarvis-branch: ${{ inputs.jarvis-branch }}
           pre-test-command: ${{ inputs.pre-test-command }}
           test-command: ${{ inputs.cypress-functional-command }}
@@ -684,6 +686,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           use-asdf: ${{ inputs.use-asdf }}
+          cache-mode: ${{ inputs.cache-mode }}
+          disable-restore-keys: ${{ inputs.disable-restore-keys }}
           jarvis-branch: ${{ inputs.jarvis-branch }}
           pre-test-command: ${{ inputs.pre-test-command }}
           test-command: ${{ inputs.cypress-visual-command }}

--- a/shared-actions/run-cypress-functional/action.yml
+++ b/shared-actions/run-cypress-functional/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: 'Use asdf-vm for version management'
     required: false
     default: 'false'
+  cache-mode:
+    description: 'Cache strategy: "full" (node_modules + yarn cache), "node_modules-only", or "yarn-cache-only"'
+    required: false
+    default: 'full'
+  disable-restore-keys:
+    description: 'Disable restore-keys to avoid restoring stale caches (forces exact key match)'
+    required: false
+    default: 'false'
   jarvis-branch:
     description: 'Jarvis branch to use (empty = npm version)'
     required: false
@@ -70,6 +78,8 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         use-asdf: ${{ inputs.use-asdf }}
+        cache-mode: ${{ inputs.cache-mode }}
+        disable-restore-keys: ${{ inputs.disable-restore-keys }}
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
     
     - name: Setup Jarvis

--- a/shared-actions/run-cypress-visual/action.yml
+++ b/shared-actions/run-cypress-visual/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: 'Use asdf-vm for version management'
     required: false
     default: 'false'
+  cache-mode:
+    description: 'Cache strategy: "full" (node_modules + yarn cache), "node_modules-only", or "yarn-cache-only"'
+    required: false
+    default: 'full'
+  disable-restore-keys:
+    description: 'Disable restore-keys to avoid restoring stale caches (forces exact key match)'
+    required: false
+    default: 'false'
   jarvis-branch:
     description: 'Jarvis branch to use (empty = npm version)'
     required: false
@@ -88,6 +96,8 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         use-asdf: ${{ inputs.use-asdf }}
+        cache-mode: ${{ inputs.cache-mode }}
+        disable-restore-keys: ${{ inputs.disable-restore-keys }}
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
     
     - name: Setup Jarvis


### PR DESCRIPTION
## Overview

Fix hall-of-forms Cypress Functional job timing out at the 20-minute limit on release workflows. The `run-cypress-functional` and `run-cypress-visual` composite actions were not forwarding `cache-mode` and `disable-restore-keys` inputs to `setup-node-with-cache`, causing projects that set `cache-mode: "node_modules-only"` (like hall-of-forms) to fall back to the default `"full"` mode in Cypress jobs.

This resulted in mismatched cache keys → stale asdf restore-key fallback → hundreds of tar errors during extraction (~3-5 min wasted) → job timeout.

## Changes

- Add `cache-mode` and `disable-restore-keys` inputs to `run-cypress-functional/action.yml` and forward them to `setup-node-with-cache`
- Add `cache-mode` and `disable-restore-keys` inputs to `run-cypress-visual/action.yml` and forward them to `setup-node-with-cache`
- Forward both inputs from `frontend-deploy-workflow.yml` Cypress jobs to the composite actions
- Forward both inputs from `frontend-pr-workflow.yml` Cypress jobs to the composite actions

## Backward Compatibility

Both new inputs default to `"full"` / `"false"` respectively, matching the existing `setup-node-with-cache` defaults. No changes needed in calling repos that do not set these inputs.

## Testing

After merging, trigger a hall-of-forms release to verify:
1. Cache restore completes without tar errors
2. Cypress Functional job finishes within the 20-minute timeout
3. Cache keys match between build and Cypress jobs