### PR TITLE
Add list of dependencies

### DIFF
--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -115,7 +115,7 @@ jobs:
             ```
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
-            ${{ steps.dependencies.outputs.result && format('**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
+            ${{ steps.dependencies.outputs.result && format('\n**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
 
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v5
@@ -133,6 +133,6 @@ jobs:
             ```
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
-            ${{ steps.dependencies.outputs.result && format('**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
+            ${{ steps.dependencies.outputs.result && format('\n**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -115,7 +115,8 @@ jobs:
             ```
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
-            ${{ steps.dependencies.outputs.result && format('\n**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
+
+            ${{ steps.dependencies.outputs.result && format('**Dependencies**: {0}', steps.dependencies.outputs.result) || '' }}
 
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v5
@@ -133,6 +134,7 @@ jobs:
             ```
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
-            ${{ steps.dependencies.outputs.result && format('\n**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
+
+            ${{ steps.dependencies.outputs.result && format('**Dependencies**: {0}', steps.dependencies.outputs.result) || '' }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/comment-deploy-link.yaml
+++ b/.github/workflows/comment-deploy-link.yaml
@@ -20,6 +20,11 @@ on:
         type: boolean
         required: false
         default: false
+      dependencies:
+        description: 'Comma-separated list of services required in the environment before this service can be deployed'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   comment:
@@ -79,6 +84,21 @@ jobs:
           issue-number: ${{ github.event.number }}
           body-includes: "Deploy this version of `${{ inputs.service }}` in"
 
+      - name: Build dependencies list
+        uses: actions/github-script@v8
+        id: dependencies
+        if: inputs.dependencies != ''
+        with:
+          script: |
+            const deps = `${{ inputs.dependencies }}`
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+              .map(dep => `\`${dep}\``)
+              .join(', ')
+            return deps
+          result-encoding: string
+
       - name: Create Comment
         uses: peter-evans/create-or-update-comment@v5
         if: steps.find-comment.outputs.comment-id == ''
@@ -95,6 +115,7 @@ jobs:
             ```
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
+            ${{ steps.dependencies.outputs.result && format('**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
 
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v5
@@ -112,5 +133,6 @@ jobs:
             ```
             🚀 Deploy this version of `${{ inputs.service }}` in an **ephemeral environment** with `--reference`:
             ${{ steps.set-result.outputs.result }}
+            ${{ steps.dependencies.outputs.result && format('**Dependencies:** {0}', steps.dependencies.outputs.result) || '' }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace


### PR DESCRIPTION
If a project requires another service to run in the same ephemeral environement we can now specify/remind/show new users to those projects what dependencies are needed.

Multiple deps can be specified like so: `'service, another-service'`