### PR TITLE
feat: add deprecation notice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Note: Please do not use this repository for new internal shared workflows and actions. Use https://github.com/Typeform/.github-private instead!
+
+Please check that your contribution applies to one of these cases below. If this is not the case, please contribute to https://github.com/Typeform/.github-private instead.
+- [ ] This PR only changes an existing workflow.
+- [ ] This PR adds a new workflow that is needed in a public Typeform repository.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,1 @@
 * @Typeform/delivery-experience
-.github/workflows/go-lint-workflow.yaml                     @Typeform/delivery-experience
-.github/workflows/image-multiarch.yaml                      @Typeform/delivery-experience
-reusable-workflows/go-lint                                  @Typeform/delivery-experience
-reusable-workflows/image-multiarch                          @Typeform/delivery-experience
-shared-actions/send-deployment-event                        @Typeform/delivery-experience
-workflow-templates/send-deployment-event.properties.json    @Typeform/delivery-experience
-workflow-templates/send-deployment-event.svg                @Typeform/delivery-experience
-workflow-templates/send-deployment-event.yml                @Typeform/delivery-experience
-workflow-templates/ci-standard-checks.yml                   @Typeform/delivery-experience
-workflow-templates/ci-standard-checks.svg                   @Typeform/delivery-experience
-workflow-templates/ci-standard-checks.properties.json       @Typeform/delivery-experience
-workflow-templates/frontend-canary-cleanup.yml              @Typeform/delivery-experience
-workflow-templates/frontend-canary-cleanup.svg              @Typeform/delivery-experience
-workflow-templates/frontend-canary-cleanup.properties.json  @Typeform/delivery-experience

--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,8 @@
 # .github
-A repository gathering commonly used typeform GitHub Workflows and Actions
+
+A repository gathering commonly used GitHub Workflows and Actions in Typeform public repositories.
+
+Note: Please do not use this repository for new internal shared workflows and actions. Use https://github.com/Typeform/.github-private instead.
 
 ## Contributing
 ⚠️ This is a public repository. To avoid leaking API tokens, passwords, or other sensitive data please enable a custom git hook for that purpose. To activate it run:
@@ -7,10 +10,5 @@ A repository gathering commonly used typeform GitHub Workflows and Actions
 make enable-git-hooks
 ```
 
-All code should pass tests, as well as be well documented. [Please also see the Commit Message Guidelines](CONTRIBUTING.MD) for how commit messages should be structured.
+All code should pass tests, as well as be well documented. [Please also see the Commit Message Guidelines](CONTRIBUTING.md) for how commit messages should be structured.
 
-## Credits
-
-[Yeti Vector Art by ayaankabir in Vecteezy](https://www.vecteezy.com/vector-art/125972-yeti-vector)
-
-[Vector drawing of twitter bird published by OpenClipart in Freesvg.org](https://freesvg.org/vector-drawing-of-twitter-bird)


### PR DESCRIPTION
https://typeform.atlassian.net/browse/PLT-3430

Deprecate this repository for internal workflows. We can still make changes to existing ones, but will move them gradually to https://github.com/Typeform/.github-private