### PR TITLE
perf(ci): run unit-tests in parallel with build in frontend-pr-workflow

### DIFF
--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -375,11 +375,10 @@ jobs:
           path: ${{ inputs.build-artifact-path || inputs.build-output-dir }}
           retention-days: 1
   
-  # Job 2: Unit Tests (parallel with integration tests)
+  # Job 2: Unit Tests (parallel with build — does not consume build artifacts)
   unit-tests:
     name: 🧪 Unit Tests
     if: inputs.run-unit-tests
-    needs: build
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: ${{ inputs.test-timeout }}
     


### PR DESCRIPTION
## Summary

- Removes `needs: build` from the `unit-tests` job in `frontend-pr-workflow.yml`.
- `unit-tests` does not consume the build artifact (no `Download Build Artifacts` step, no `needs.build.outputs.*` reference) and already re-runs any required codegen in `pre-test-command`. The dependency only serialized the pipeline for no functional gain.
- After this change, `unit-tests` runs in parallel with `build`, shortening PR feedback time.

## Scope

Investigated all 32 frontend repos migrated to the unified CI pipeline (PLT-2547):

- **18 repos actively benefit** — jest-only test suites or `pre-test-command: yarn generate` that is self-contained (smart-forms-builder, audiences-page, admin-panel, followups-manager, typeform-ai, authbridge-fe, auth-page, boombox-fe, cha-ching, hall-of-forms, paprikations, typekit-app-directory, share-web, workflows, results, integrations-panel, chief, demo-app).
- **10 repos unaffected** — don't call this workflow, or don't run unit tests via it.
- **4 repos with workspace-aware pre-test** — admin-template-gallery, brand-kit-frontend, app-shell, performance-analytics. All handle their test prereqs via `pre-test-command` independently of the `build` job, so removing the dep is safe.

## Validation

End-to-end test against `performance-analytics` (the repo with the most complex pre-test — Turbo workspace rebuilds + GraphQL codegen):

- Pointed [Typeform/performance-analytics#2008](https://github.com/Typeform/performance-analytics/pull/2008) at `@test/unit-tests-no-build-dep`.
- **Unit Tests started 14:17:08; Build started 14:17:18** — parallel execution confirmed.
- Unit Tests completed in **6m44s** (while Build took 3m48s).
- No Turbo cache contention or codegen ordering issues observed.

Time savings on this PR: ~3m48s on the unit-tests critical path (equal to the full build duration, because unit-tests > build here). For repos where unit-tests < build, savings equal the unit-tests duration on any path that gates on unit-tests completion (e.g. SonarCloud, which currently `needs: [build, unit-tests]`).

Flakes observed during validation were pre-existing (intermittent GraphQL schema fetches, Playwright timeouts) and reproduce on unmodified PRs.

## Test plan

- [x] Validated against performance-analytics with end-to-end rerun
- [x] Confirmed Unit Tests starts before Build in parallel mode
- [ ] Monitor next-day CI for regression reports across affected repos

---

- [x] This PR only changes an existing workflow.
- [ ] This PR adds a new workflow that is needed in a public Typeform repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)