### PR TITLE
fix: Fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,23 @@
-Note: Please do not use this repository for new internal shared workflows and actions. Use https://github.com/Typeform/.github-private instead!
+# Overview
 
-Please check that your contribution applies to one of these cases below. If this is not the case, please contribute to https://github.com/Typeform/.github-private instead.
-- [ ] This PR only changes an existing workflow.
-- [ ] This PR adds a new workflow that is needed in a public Typeform repository.
+Jira ticket: https://typeform.atlassian.net/browse/<TICKET_ID>
+
+<!-- Include a brief overview of what this PR is about.
+ i.e.: what problem does it solve? what feature does it add?
+ -->
+
+## Changes
+
+<!-- Relevant changes to guide the reviewer through your PR -->
+
+-
+-
+-
+
+## Testing
+
+<!-- Test artefacts, such as screenshots, logs, ... -->
+
+## Docs
+
+- [ ] **Yes!** :hand: I have updated the documentation.

--- a/.github/PULL_REQUEST_TEMPLATE/branches/main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/branches/main.md
@@ -1,0 +1,5 @@
+Note: Please do not use this repository for new internal shared workflows and actions. Use https://github.com/Typeform/.github-private instead!
+
+Please check that your contribution applies to one of these cases below. If this is not the case, please contribute to https://github.com/Typeform/.github-private instead.
+- [ ] This PR only changes an existing workflow.
+- [ ] This PR adds a new workflow that is needed in a public Typeform repository.


### PR DESCRIPTION
[PLT-3430](https://typeform.atlassian.net/browse/PLT-3430)

The PR template was accidentally applied to all repos in Typeform that don't have a PR template.

This introduces:
- An alternative PR template that's appropriate for the whole org
- A PR template just for PRs to main in this repo, which includes specifics about this repo


Note: Please do not use this repository for new internal shared workflows and actions. Use https://github.com/Typeform/.github-private instead!

Please check that your contribution applies to one of these cases below. If this is not the case, please contribute to https://github.com/Typeform/.github-private instead.
- [x] This PR only changes an existing workflow.
- [x] This PR adds a new workflow that is needed in a public Typeform repository.


[PLT-3430]: https://typeform.atlassian.net/browse/PLT-3430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ