### PR TITLE
fix: remove --frozen-lockfile from yarn install

### DIFF
--- a/shared-actions/setup-node-with-cache/action.yml
+++ b/shared-actions/setup-node-with-cache/action.yml
@@ -333,7 +333,7 @@ runs:
     - name: Install Node.js dependencies
       if: ${{ !env.ACT && (steps.yarn-cache.outputs.cache-hit != 'true' || steps.check-install-needed.outputs.needs-install == 'true') }}
       shell: bash
-      run: yarn install --frozen-lockfile --ignore-scripts
+      run: yarn install --ignore-scripts
       env:
         NODE_AUTH_TOKEN: ${{ inputs.GH_TOKEN }}
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'


### PR DESCRIPTION
## Summary

- Removes `--frozen-lockfile` flag from the `yarn install` command in the `setup-node-with-cache` shared action
- This allows yarn to update the lockfile during install rather than failing if it's out of sync

## Test plan

- [ ] Verify CI workflows using this action still install dependencies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)