### PR TITLE
fix: use GH_TOKEN for record-verification push instead

### DIFF
--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -721,12 +721,12 @@ jobs:
       (inputs.run-playwright-visual == false || needs.playwright-visual.result == 'success') &&
       (inputs.run-unit-tests || inputs.run-integration-tests || inputs.run-cypress-functional || inputs.run-cypress-visual || inputs.run-playwright-visual)
     runs-on: ${{ fromJSON(inputs.runner) }}
-    permissions:
-      contents: write
 
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Push tree-hash marker
         run: |


### PR DESCRIPTION
Hotfix for CI breakage introduced in v1.53.0.

The `record-verification` job declared `permissions: contents: write`, which GitHub requires every calling workflow to also explicitly grant. Consumer repos that don't (some don't) get a workflow validation error blocking all PRs.

Fix: drop the job-level permissions block and pass `GH_TOKEN` to `actions/checkout` instead - the git push uses the PAT, so no permission grant is needed from the calling side. Safe to use because all consumer workflows use `GH_TOKEN` for S3, posting comments etc.

No behavior change - marker is still written the same way.