### PR TITLE
fix(NO-JIRA): pin datadog-ci to 5.21.0 instead of @latest

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -750,7 +750,7 @@ jobs:
         if: inputs.jarvis-datadog-enabled
         continue-on-error: true
         run: |
-          npx --yes @datadog/datadog-ci@latest tag --level pipeline \
+          npx --yes @datadog/datadog-ci@5.21.0 tag --level pipeline \
             --tags "workflow_version:${{ env.WORKFLOW_VERSION }}" \
             --tags "workflow_file:${{ env.WORKFLOW_FILE }}"
         env:

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -567,7 +567,7 @@ jobs:
         if: inputs.jarvis-datadog-enabled
         continue-on-error: true
         run: |
-          npx --yes @datadog/datadog-ci@latest tag --level pipeline \
+          npx --yes @datadog/datadog-ci@5.21.0 tag --level pipeline \
             --tags "workflow_version:${{ env.WORKFLOW_VERSION }}" \
             --tags "workflow_file:${{ env.WORKFLOW_FILE }}"
         env:


### PR DESCRIPTION
# Overview

Jira ticket: N/A

Pin `@datadog/datadog-ci` from `@latest` to `5.21.0` in both shared frontend workflows (`frontend-deploy-workflow.yml` and `frontend-pr-workflow.yml`).

`@latest` resolves at runtime and can silently pull breaking changes. Pinning to a specific version ensures deterministic, reproducible CI behavior.

## Changes

- Replace `@datadog/datadog-ci@latest` → `@datadog/datadog-ci@5.21.0` in `frontend-deploy-workflow.yml`
- Replace `@datadog/datadog-ci@latest` → `@datadog/datadog-ci@5.21.0` in `frontend-pr-workflow.yml`

## Testing

No functional change — same command, pinned version.

## Docs

- [ ] **Yes!** :hand: I have updated the documentation.

## For contributions to the `Typeform/.github` repo

- [x] This PR only changes an existing workflow.