### PR TITLE
fix(setup-node-with-cache): force install for deploy jobs with tooling dependencies

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -678,7 +678,7 @@ jobs:
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-      
+
       - name: Setup Node with Cache
         uses: Typeform/.github/shared-actions/setup-node-with-cache@v1
         with:
@@ -688,7 +688,8 @@ jobs:
           disable-restore-keys: ${{ inputs.disable-restore-keys }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           package-manager: ${{ inputs.package-manager }}
-      
+          force-install: true  # Deploy jobs need tooling dependencies (e.g., @datadog/datadog-ci)
+
       - name: Download Build Artifacts
         uses: Typeform/.github/shared-actions/download-build-artifacts@v1
         with:

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -509,7 +509,7 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6
-      
+
       - name: Setup Node with Cache
         uses: Typeform/.github/shared-actions/setup-node-with-cache@v1
         with:
@@ -519,7 +519,8 @@ jobs:
           disable-restore-keys: ${{ inputs.disable-restore-keys }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           package-manager: ${{ inputs.package-manager }}
-      
+          force-install: true  # Deploy jobs need tooling dependencies (e.g., @datadog/datadog-ci)
+
       - name: Download Build Artifacts
         uses: Typeform/.github/shared-actions/download-build-artifacts@v1
         with:

--- a/shared-actions/setup-node-with-cache/README.md
+++ b/shared-actions/setup-node-with-cache/README.md
@@ -37,6 +37,7 @@ Standardized Node.js setup with enhanced yarn/pnpm caching and GitHub packages r
 | `enable-yarn-cache` | Enable yarn global cache (~/.cache/yarn) | No | `'true'` |
 | `cache-mode` | Cache strategy: `full`, `node_modules-only`, `yarn-cache-only`, or `pnpm-store-only` | No | `'full'` |
 | `disable-restore-keys` | Disable restore-keys to avoid restoring stale caches | No | `'false'` |
+| `force-install` | Force install even on cache hit (required for deploy jobs that need tooling dependencies) | No | `'false'` |
 
 **📖 Need help choosing the right cache mode?** See the [Cache Strategy Guide](./CACHE-STRATEGY-GUIDE.md) for detailed recommendations.
 
@@ -63,6 +64,7 @@ None
 8. **Logs cache status** with detailed debug information
 9. **Installs dependencies** automatically on cache miss or verification failure
 10. **Smart install detection** on cache hit (after verification):
+    - **force-install=true**: ALWAYS runs install (needed for deploy jobs with tooling dependencies)
     - **Workspaces**: ALWAYS runs install (needs workspace symlink creation)
     - **Lerna monorepos**: Runs install (needs lerna bootstrap)
     - **Postinstall hooks**: Runs install (needs hook execution)
@@ -218,6 +220,15 @@ act pull_request -j build
     disable-restore-keys: 'true'
 ```
 **Use when**: You want to avoid restoring large stale caches. Only exact cache key matches will be restored.
+
+### Force Install (Deploy Jobs)
+```yaml
+- uses: Typeform/.github/shared-actions/setup-node-with-cache@main
+  with:
+    GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    force-install: true  # Always run install, needed for deploy jobs with tooling dependencies
+```
+**Use when**: Your job runs deployment commands that depend on tooling packages (e.g., `@datadog/datadog-ci` for sourcemap uploads). Deploy jobs in shared workflows automatically set this to `true`.
 
 ### Disable Yarn Global Cache
 ```yaml

--- a/shared-actions/setup-node-with-cache/action.yml
+++ b/shared-actions/setup-node-with-cache/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Package manager to use: "yarn" or "pnpm"'
     required: false
     default: "yarn"
+  force-install:
+    description: 'Force install even on cache hit (required for deploy jobs that need tooling dependencies)'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -307,7 +311,7 @@ runs:
       shell: bash
       run: |
         set +e  # Don't exit on error - we want to check all conditions
-        
+
         # Determine if we need to run install even when cache hits.
         #
         # Why this matters:
@@ -315,11 +319,18 @@ runs:
         # - Monorepos need workspace linking even with cached node_modules
         # - Some projects have critical postinstall scripts (e.g., building native modules)
         # - Cached node_modules might be incomplete or corrupted
+        # - Deploy jobs need tooling dependencies (e.g., @datadog/datadog-ci) to be available
         #
         # We detect scenarios that require yarn install on cache hit:
-        
+
         PM="${{ inputs.package-manager }}"
         NEEDS_INSTALL=false
+
+        # Force install if explicitly requested (deploy jobs, etc.)
+        if [ "${{ inputs.force-install }}" == "true" ]; then
+          echo "🔄 force-install=true - install will run even on cache hit"
+          NEEDS_INSTALL=true
+        fi
 
         if [ "$PM" == "pnpm" ]; then
           CACHE_HIT="${{ steps.pnpm-cache.outputs.cache-hit }}"


### PR DESCRIPTION
## Description

pnpm deploy jobs were failing with `datadog-ci: not found` when Jarvis tried to upload sourcemaps to Datadog. The shared cache action's install-skipping logic allowed pnpm repos with cache hits to skip install entirely when the cache looked intact and no workspaces/postinstall hooks were detected.

This worked fine for yarn-based deploys, but pnpm's cache-first strategy exposed a gap: **deploy jobs need tooling dependencies like `@datadog/datadog-ci` to be available**, even when the cache hit allows install to be skipped for build/test jobs.

### Root Cause

The shared action's `check-install-needed` step verified cache integrity and checked for workspaces/lerna/postinstall hooks, but didn't account for deploy jobs that shell out to tooling packages (e.g., `npx @datadog/datadog-ci@5.21.0`).

For pnpm repos like admin-home using `cache-mode: full`: cache hit + no workspaces + no postinstall = skip install entirely. The deploy job then ran `pnpm deploy` (which invokes Jarvis), and Jarvis's Datadog sourcemap upload step failed.

### Solution

Added a new `force-install` input to the shared action that signals "this job needs tooling dependencies, always run install." Set it to `true` in deploy jobs for both production (`frontend-deploy-workflow.yml`) and preview (`frontend-pr-workflow.yml`).

The logic short-circuits at the top of the install-needed check so deploy jobs always run install after cache restore, regardless of cache integrity or repo structure. This keeps the performance optimization for build/test jobs intact.

### Changes

- **`shared-actions/setup-node-with-cache/action.yml`**: Added `force-install` input and check
- **`.github/workflows/frontend-deploy-workflow.yml`**: Set `force-install: true` in deploy job
- **`.github/workflows/frontend-pr-workflow.yml`**: Set `force-install: true` in preview deploy job
- **`shared-actions/setup-node-with-cache/README.md`**: Documented the new input with usage examples

### Impact

- ✅ Fixes production deploy failure for `admin-home` and other pnpm repos deploying with Jarvis + Datadog
- ✅ Platform-level fix — no per-repo workarounds needed
- ✅ Preserves cache-performance optimizations for build/test jobs

## Testing

The fix ensures that for pnpm deploy jobs with `cache-mode: full`:
1. Cache hit still happens (restores `node_modules` + pnpm store)
2. Install runs anyway (because `force-install=true`)
3. Tooling dependencies like `@datadog/datadog-ci` are available
4. Jarvis's Datadog sourcemap upload succeeds
5. Deploy completes normally

For build/test jobs, `force-install` remains `false` (default) so existing behavior is unchanged.

___
🤖 *Generated by Glean Code Writer*
📝 Chat link - https://app.glean.com/chat/c40e4a74a89147fca97c44e098bd8d08