### PR TITLE
chore(PLT-3524): remove SonarCloud from shared frontend workflows

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -227,17 +227,19 @@ on:
         type: number
         default: 20
       
-      # SonarCloud configuration
+      # SonarCloud configuration (DEPRECATED — SonarCloud has been decommissioned;
+      # these inputs are retained as no-ops for backward compatibility and will be
+      # removed in a future major version).
       run-sonarcloud:
-        description: 'Run SonarCloud analysis'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: boolean
-        default: true
+        default: false
       sonarcloud-timeout:
-        description: 'SonarCloud job timeout (minutes)'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: number
         default: 10
       sonarcloud-wait-for-tests:
-        description: 'Wait for unit tests to complete before running SonarCloud'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: boolean
         default: true
       
@@ -265,7 +267,7 @@ on:
 
       # Skip verified tests
       skip-verified-tests:
-        description: 'Skip unit/integration/cypress/sonarcloud on main if the same tree passed on the PR. Requires record-verification job in the PR workflow. Set false to always re-run on main.'
+        description: 'Skip unit/integration/cypress on main if the same tree passed on the PR. Requires record-verification job in the PR workflow. Set false to always re-run on main.'
         type: boolean
         default: true
       
@@ -278,6 +280,7 @@ on:
       GH_TOKEN:
         required: true
       SONAR_CLOUD_TOKEN:
+        # DEPRECATED — SonarCloud is decommissioned. Secret is no longer consumed.
         required: false
       DATADOG_API_KEY:
         required: false
@@ -423,9 +426,7 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Required for SonarCloud
-      
+
       - name: Setup Node with Cache
         uses: Typeform/.github/shared-actions/setup-node-with-cache@v1
         with:
@@ -620,26 +621,11 @@ jobs:
           VRT_PROJECT: ${{ secrets.VRT_PROJECT }}
           package-manager: ${{ inputs.package-manager }}
 
-  # Job 7: SonarCloud Analysis (waits for unit tests if enabled)
-  sonarcloud:
-    name: 🔍 SonarCloud
-    if: inputs.run-sonarcloud && needs.check-verification.outputs.verified != 'true'
-    needs: [build, unit-tests, check-verification]
-    permissions:
-      contents: read
-    uses: Typeform/.github/.github/workflows/sonarcloud-scan.yml@v1
-    with:
-      app-name: ${{ inputs.app-name }}
-      node-version: ${{ inputs.node-version }}
-      use-asdf: ${{ inputs.use-asdf }}
-      runner: ${{ inputs.runner }}
-      coverage-artifact-name: ${{ inputs.run-unit-tests && format('coverage-{0}', github.run_id) || '' }}
-      timeout: ${{ inputs.sonarcloud-timeout }}
-      package-manager: ${{ inputs.package-manager }}
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      SONAR_CLOUD_TOKEN: ${{ secrets.SONAR_CLOUD_TOKEN }}
-  
+  # Job 7: SonarCloud Analysis — REMOVED (SonarCloud has been decommissioned).
+  # The `run-sonarcloud`, `sonarcloud-timeout`, `sonarcloud-wait-for-tests` inputs
+  # and `SONAR_CLOUD_TOKEN` secret above are retained as no-ops for backward
+  # compatibility.
+
   # Job 8: Deploy to Production (only if all enabled tests pass or were skipped as verified)
   deploy:
     name: 🚀 Deploy to Production

--- a/.github/workflows/frontend-library-pr-release-workflow.yml
+++ b/.github/workflows/frontend-library-pr-release-workflow.yml
@@ -43,14 +43,16 @@ on:
         type: string
         default: '["main", "beta", "alpha", "next"]'
       
-      # SonarCloud
+      # SonarCloud (DEPRECATED — SonarCloud has been decommissioned; these inputs
+      # are retained as no-ops for backward compatibility and will be removed in a
+      # future major version).
       run-sonarcloud:
-        description: 'Run SonarCloud scan'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: boolean
-        default: true
-      
+        default: false
+
       sonar-project-key:
-        description: 'SonarCloud project key (defaults to repository name)'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: string
         default: ''
       
@@ -74,6 +76,7 @@ on:
       GH_TOKEN:
         required: true
       SONAR_CLOUD_TOKEN:
+        # DEPRECATED — SonarCloud is decommissioned. Secret is no longer consumed.
         required: false
 
 permissions:
@@ -95,7 +98,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # Required for SonarCloud and semantic-release
+          fetch-depth: 0  # Required for semantic-release
       
       - name: Setup Node with Cache
         uses: Typeform/.github/shared-actions/setup-node-with-cache@main
@@ -122,14 +125,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.GH_TOKEN }}
       
-      - name: SonarCloud Scan
-        if: inputs.run-sonarcloud
-        uses: SonarSource/sonarqube-scan-action@v8
-        with:
-          args: >
-            -Dsonar.projectKey=${{ inputs.sonar-project-key != '' && inputs.sonar-project-key || format('{0}_{1}', github.repository_owner, github.event.repository.name) }}
-            -Dsonar.projectVersion=${{ github.run_id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_CLOUD_TOKEN }}
-          LC_ALL: "C.UTF-8"
+      # SonarCloud Scan — REMOVED (SonarCloud has been decommissioned).
+      # The `run-sonarcloud`, `sonar-project-key` inputs and `SONAR_CLOUD_TOKEN`
+      # secret above are retained as no-ops for backward compatibility.

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -113,13 +113,15 @@ on:
         type: string
         default: 'none'
       
-      # SonarCloud configuration
+      # SonarCloud configuration (DEPRECATED — SonarCloud has been decommissioned;
+      # these inputs are retained as no-ops for backward compatibility and will be
+      # removed in a future major version).
       run-sonarcloud:
-        description: 'Run SonarCloud analysis'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: boolean
-        default: true
+        default: false
       sonarcloud-timeout:
-        description: 'SonarCloud job timeout (minutes)'
+        description: 'DEPRECATED — SonarCloud is decommissioned. Input is a no-op.'
         type: number
         default: 10
       
@@ -276,6 +278,7 @@ on:
       GH_TOKEN:
         required: true
       SONAR_CLOUD_TOKEN:
+        # DEPRECATED — SonarCloud is decommissioned. Secret is no longer consumed.
         required: false
       DATADOG_API_KEY:
         required: false
@@ -579,28 +582,10 @@ jobs:
           echo "The commit SHA is ${{ github.sha }}"
           echo "📋 Workflow: frontend-pr-workflow (v2)"
   
-  # Job 5: SonarCloud Analysis (waits for unit tests if enabled, otherwise runs immediately)
-  sonarcloud:
-    name: 🔍 SonarCloud
-    if: inputs.run-sonarcloud
-    needs: [build, unit-tests]
-    permissions:
-      contents: read
-    uses: Typeform/.github/.github/workflows/sonarcloud-scan.yml@v1
-    with:
-      app-name: ${{ inputs.app-name }}
-      node-version: ${{ inputs.node-version }}
-      use-asdf: ${{ inputs.use-asdf }}
-      cache-mode: ${{ inputs.cache-mode }}
-      disable-restore-keys: ${{ inputs.disable-restore-keys }}
-      runner: ${{ inputs.runner }}
-      coverage-artifact-name: ${{ inputs.run-unit-tests && format('coverage-{0}', github.run_id) || '' }}
-      timeout: ${{ inputs.sonarcloud-timeout }}
-      package-manager: ${{ inputs.package-manager }}
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      SONAR_CLOUD_TOKEN: ${{ secrets.SONAR_CLOUD_TOKEN }}
-  
+  # Job 5: SonarCloud Analysis — REMOVED (SonarCloud has been decommissioned).
+  # The `run-sonarcloud`, `sonarcloud-timeout` inputs and `SONAR_CLOUD_TOKEN`
+  # secret above are retained as no-ops for backward compatibility.
+
   # Job 6: GraphQL Persisted Operations (parallel with tests)
   graphql-persisted-operations:
     name: 🔐 GraphQL Persisted Operations

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -1,100 +1,57 @@
 #trigger changes
-name: SonarCloud Scan
+name: SonarCloud Scan (DEPRECATED)
+
+# DEPRECATED — SonarCloud has been decommissioned. This workflow is kept as a
+# no-op for backward compatibility with any external caller still referencing
+# `Typeform/.github/.github/workflows/sonarcloud-scan.yml@v1`. It logs a
+# deprecation notice and exits successfully.
 
 on:
   workflow_call:
     inputs:
-      # Project identification
       app-name:
-        description: 'Application name (must match sonar.projectKey in sonar-project.properties)'
         type: string
-        required: true
-      
-      # Node configuration
+        required: false
       node-version:
-        description: 'Node.js version (ignored if use-asdf is true)'
         type: string
-        default: '20'
+        required: false
       use-asdf:
-        description: 'Use asdf-vm for version management (reads from .tool-versions)'
         type: boolean
-        default: false
+        required: false
       cache-mode:
-        description: 'Cache strategy: full, node_modules-only, or yarn-cache-only'
         type: string
-        default: 'full'
+        required: false
       disable-restore-keys:
-        description: 'Disable restore-keys to avoid restoring stale caches (forces exact key match)'
         type: boolean
-        default: false
+        required: false
       package-manager:
-        description: 'Package manager to use: "yarn" or "pnpm"'
         type: string
-        default: "yarn"
-      
-      # Runner configuration
+        required: false
       runner:
-        description: 'Runner for SonarCloud scan'
         type: string
-        default: '[ci-universal-scale-set]'
-      
-      # Coverage configuration
+        required: false
       coverage-artifact-name:
-        description: 'Name of coverage artifact to download (optional, e.g., coverage-12345)'
         type: string
-        default: ''
-      
-      # Timeout configuration
+        required: false
       timeout:
-        description: 'Job timeout (minutes)'
         type: number
-        default: 10
-    
+        required: false
+
     secrets:
       GH_TOKEN:
-        required: true
+        required: false
       SONAR_CLOUD_TOKEN:
-        required: true
+        required: false
 
 permissions:
   contents: read
 
 jobs:
   sonarcloud:
-    name: 🔍 SonarCloud Analysis
-    runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: ${{ inputs.timeout }}
-    
+    name: 🔍 SonarCloud Analysis (deprecated no-op)
+    runs-on: ubuntu-latest
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0  # Required for SonarCloud to analyze git history
-      
-      - name: Setup Node with Cache
-        uses: Typeform/.github/shared-actions/setup-node-with-cache@v1
-        with:
-          node-version: ${{ inputs.node-version }}
-          use-asdf: ${{ inputs.use-asdf }}
-          cache-mode: ${{ inputs.cache-mode }}
-          disable-restore-keys: ${{ inputs.disable-restore-keys }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          package-manager: ${{ inputs.package-manager }}
-      
-      - name: Download coverage artifacts
-        if: inputs.coverage-artifact-name != ''
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ inputs.coverage-artifact-name }}
-          path: coverage/
-        continue-on-error: true
-      
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v8
-        with:
-          args: >
-            -Dsonar.projectVersion=${{ github.run_id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_CLOUD_TOKEN }}
-          LC_ALL: "C.UTF-8"
+      - name: Deprecation notice
+        run: |
+          echo "::warning::SonarCloud has been decommissioned. This workflow is a no-op."
+          echo "::warning::Remove any 'uses: Typeform/.github/.github/workflows/sonarcloud-scan.yml' entry from your workflows."


### PR DESCRIPTION
Jira link: https://typeform.atlassian.net/browse/PLT-3524

SonarCloud has been decommissioned. This PR removes the SonarCloud analysis job/step from the shared frontend workflows and neuters the standalone `sonarcloud-scan.yml`. The `run-sonarcloud` / `sonarcloud-timeout` / `sonarcloud-wait-for-tests` / `sonar-project-key` inputs and the `SONAR_CLOUD_TOKEN` secret are kept as no-op deprecated for backward compatibility with existing callers.

Affected workflows:
- `frontend-pr-workflow.yml` — sonar job removed.
- `frontend-deploy-workflow.yml` — sonar job removed; dropped stale `fetch-depth: 0` (only needed for sonar) on the unit-tests checkout.
- `frontend-library-pr-release-workflow.yml` — inline sonar step removed.
- `sonarcloud-scan.yml` — reduced to a passing no-op that logs a deprecation warning.