### PR TITLE
fix(ci): use global install for datadog-ci and fix pnpm link syntax

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -736,7 +736,7 @@ jobs:
         if: inputs.jarvis-datadog-enabled
         continue-on-error: true
         run: |
-          npx --yes @datadog/datadog-ci@5.21.0 tag --level pipeline \
+          datadog-ci tag --level pipeline \
             --tags "workflow_version:${{ env.WORKFLOW_VERSION }}" \
             --tags "workflow_file:${{ env.WORKFLOW_FILE }}"
         env:

--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -570,7 +570,7 @@ jobs:
         if: inputs.jarvis-datadog-enabled
         continue-on-error: true
         run: |
-          npx --yes @datadog/datadog-ci@5.21.0 tag --level pipeline \
+          datadog-ci tag --level pipeline \
             --tags "workflow_version:${{ env.WORKFLOW_VERSION }}" \
             --tags "workflow_file:${{ env.WORKFLOW_FILE }}"
         env:

--- a/shared-actions/setup-jarvis/action.yml
+++ b/shared-actions/setup-jarvis/action.yml
@@ -33,11 +33,20 @@ runs:
           echo "🔗 Linking local Jarvis from /Users/kevin.barz/code/jarvis"
           JARVIS_LOCAL="/Users/kevin.barz/code/jarvis"
           if [ -f "$JARVIS_LOCAL/pnpm-lock.yaml" ]; then
-            cd "$JARVIS_LOCAL" && pnpm link
+            cd "$JARVIS_LOCAL"
+            pnpm install --frozen-lockfile
+            pnpm link
           else
-            cd "$JARVIS_LOCAL" && yarn link
+            cd "$JARVIS_LOCAL"
+            yarn install --frozen-lockfile
+            yarn link
           fi
-          cd $GITHUB_WORKSPACE && $PM link @typeform/jarvis
+          cd "$GITHUB_WORKSPACE"
+          if [ "$PM" = "pnpm" ]; then
+            pnpm link "$JARVIS_LOCAL"
+          else
+            yarn link @typeform/jarvis
+          fi
           echo "✅ Jarvis linked from local development copy"
           ls -la node_modules/@typeform/jarvis
         elif [ -n "$JARVIS_BRANCH" ]; then
@@ -59,8 +68,12 @@ runs:
             yarn link
           fi
           # Link to this project using caller's PM
-          cd $GITHUB_WORKSPACE
-          $PM link @typeform/jarvis
+          cd "$GITHUB_WORKSPACE"
+          if [ "$PM" = "pnpm" ]; then
+            pnpm link "$JARVIS_DIR"
+          else
+            yarn link @typeform/jarvis
+          fi
           
           echo "✅ Jarvis linked from GitHub branch: $JARVIS_BRANCH"
           echo "📍 Jarvis location: $JARVIS_DIR"
@@ -74,3 +87,9 @@ runs:
             echo "⚠️ Jarvis not found in node_modules - may need to run $PM install first"
           fi
         fi
+
+    - name: Install datadog-ci globally
+      shell: bash
+      run: |
+        npm install -g @datadog/datadog-ci@5.21.0
+        echo "$(npm prefix -g)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
# Overview


## Issue 1: `pnpm link` bad params in setup-jarvis

**Error**
```
[ERR_PNPM_LINK_BAD_PARAMS] Cannot link by package name.
Use a relative or absolute path instead.
```

**Why**
yarn link registers a package globally by name: `yarn link` then `yarn link @typeform/jarvis`.
pnpm link requires a path: `pnpm link /path/to/pkg`.

The `setup-jarvis` composite action was doing `pnpm link @typeform/jarvis` (name-based) after `yarn link` registered it.

**Fix** — `.github/shared-actions/setup-jarvis/action.yml`
```bash
# Before
yarn link @typeform/jarvis   # name-based — works with yarn
pnpm link @typeform/jarvis   # name-based — BREAKS with pnpm

# After
pnpm link "$JARVIS_DIR"      # path-based — correct for pnpm
```

**Where**: `Typeform/.github` repo, `deploy-pnpm` branch, commit `82782b4`.

---

## Issue 2: `datadog-ci: not found` during deploy sourcemaps upload

**Error**
```
sh: 1: datadog-ci: not found
Command failed: npx --yes @datadog/datadog-ci@5.21.0 sourcemaps upload dist ...
```

**Why**
`@datadog/datadog-ci` v5 is a meta-package. When invoked via `npx`, it downloads itself to a temp dir and internally spawns `datadog-ci` as a subprocess (looking for the binary on `$PATH`). With yarn, `datadog-ci` bin was hoisted to `node_modules/.bin` and was on PATH. With pnpm, it's not.

This was **not** a package rename issue. The package `datadog-ci` (unscoped) was deprecated; the correct package is `@datadog/datadog-ci`. But even with the correct package, v5 spawns a subprocess that needs `datadog-ci` on PATH.

**Fix — two parts:**

**Fix**: install `datadog-ci` globally in `setup-jarvis` and add it to `$GITHUB_PATH` so all subsequent steps — including subprocesses spawned by jarvis — can find the binary.

In `setup-jarvis/action.yml` (all package managers):
```yaml
- name: Install datadog-ci globally
  shell: bash
  run: |
    npm install -g @datadog/datadog-ci@5.21.0
    echo "$(npm prefix -g)/bin" >> $GITHUB_PATH
```

`$GITHUB_PATH` persists the bin path for all subsequent steps in the job, including subprocesses. `export PATH` would only work within the same shell process.

In `frontend-deploy-workflow.yml` and `frontend-pr-workflow.yml` "Tag pipeline" step — now just:
```bash
datadog-ci tag --level pipeline \
  --tags "workflow_version:..." \
  --tags "workflow_file:..."
```

No conditional, no `npx`, no per-step install.

## Testing

- Relies on CI runs with pnpm-based repos consuming `setup-jarvis`

## Docs

- [x] **Yes!** :hand: I have updated the documentation.

## For contributions to the `Typeform/.github` repo

- [x] This PR only changes an existing workflow.