### PR TITLE
fix(TU-44962): Never skip playwright/cypress visual in deploy workflow

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -560,8 +560,8 @@ jobs:
   # Job 5: Cypress Visual Tests (runs in parallel with other tests)
   cypress-visual:
     name: 🎨 Cypress Visual
-    if: inputs.run-cypress-visual && needs.check-verification.outputs.verified != 'true'
-    needs: [build, check-verification]
+    if: inputs.run-cypress-visual
+    needs: [build]
     runs-on: ${{ fromJSON(inputs.cypress-runner != '' && inputs.cypress-runner || inputs.e2e-runner) }}
     timeout-minutes: ${{ inputs.cypress-timeout }}
     
@@ -592,8 +592,8 @@ jobs:
   # Job 6: Playwright Visual Tests (runs in parallel with other tests)
   playwright-visual:
     name: 🎨 Playwright Visual
-    if: inputs.run-playwright-visual && needs.check-verification.outputs.verified != 'true'
-    needs: [build, check-verification]
+    if: inputs.run-playwright-visual
+    needs: [build]
     runs-on: ${{ fromJSON(inputs.e2e-runner) }}
     timeout-minutes: ${{ inputs.playwright-visual-timeout }}
 


### PR DESCRIPTION
# Overview

Jira ticket: https://typeform.atlassian.net/browse/TU-44962

Both playwright-visual and cypress-visual jobs were gated behind thesame verified-skip check as unit and integration tests:

```yaml
  if: inputs.run-playwright-visual &&
      needs.check-verification.outputs.verified != 'true'
```

The verified-skip optimization is correct for unit/integration: if the PR already ran those suites against the exact same git tree, there is no value re-running them on main. But it is semantically wrong for visual regression tests.

VRT baselines are scoped per branch name. On PRs, the action runs with vrt-branch-name set to the PR's head ref (e.g. feature/my-change), so all screenshots are stored under that branch in VRT. When the PR merges
and the deploy workflow runs on main, the verified-skip fires and the visual job is skipped — meaning the main-branch baseline in VRT is never written. Every subsequent PR then diffs against a stale or nonexistent main baseline, which either produces false negatives (no diff because there is no baseline) or "No baseline" errors.

Remove the verified-skip check from both playwright-visual and cypress-visual so they run on every deploy when enabled. This does not affect the deploy: neither job is listed in the deploy job's needs, so a visual diff never blocks a production release.

## Docs

- ~~**Yes!** :hand: I have updated the documentation.~~

## For contributions to the `Typeform/.github` repo

- [x] This PR only changes an existing workflow.
- ~~This PR adds a new workflow that is needed in a public Typeform repository.~~
