### PR TITLE
perf: support Deep Purple app matrices

### DIFF
--- a/.github/workflows/frontend-pr-workflow.yml
+++ b/.github/workflows/frontend-pr-workflow.yml
@@ -136,6 +136,10 @@ on:
         description: 'Run Deep Purple E2E tests'
         type: boolean
         default: false
+      deep-purple-apps:
+        description: 'JSON array of app names for Deep Purple; defaults to app-name'
+        type: string
+        default: ''
       
       # Cypress configuration
       run-cypress-functional:
@@ -599,15 +603,18 @@ jobs:
   
   # Job 7: Deep Purple E2E Tests
   deep-purple:
-    name: 🔮 Deep Purple E2E
+    name: 🔮 Deep Purple E2E (${{ matrix.app }})
     if: inputs.run-deep-purple
     needs: deploy-preview
+    strategy:
+      matrix:
+        app: ${{ fromJSON(inputs.deep-purple-apps != '' && inputs.deep-purple-apps || format('["{0}"]', inputs.app-name)) }}
     permissions:
       pull-requests: write
       contents: read
     uses: Typeform/.github/.github/workflows/deep-purple-checks.yml@v1
     with:
-      app: ${{ inputs.app-name }}
+      app: ${{ matrix.app }}
     secrets:
       JENKINS_OKTA_USERNAME: ${{ secrets.JENKINS_OKTA_USERNAME }}
       JENKINS_USER_TOKEN: ${{ secrets.JENKINS_USER_TOKEN }}


### PR DESCRIPTION
# Overview

Jira ticket: N/A

Allow monorepo callers of the existing frontend PR workflow to run Deep Purple once per affected app immediately after preview deployment. Single-app callers keep the current `app-name` behavior.

## Changes

- add an optional `deep-purple-apps` JSON-array input
- expand the existing Deep Purple reusable-workflow job with a matrix when that input is provided
- preserve `app-name` as the fallback for existing callers

## Testing

- YAML parses successfully locally
- `Typeform/performance-analytics` consumed this branch from draft PR #2279
- a dummy `responses-analytics` change produced exactly one Deep Purple matrix job
- Deep Purple started after Deploy Preview while Integration Tests were still running
- the complete consumer workflow passed in 10m22s; Deep Purple passed in 3m16s

## Docs

- [ ] **Yes!** :hand: I have updated the documentation.

## For contributions to the `Typeform/.github` repo

Note: Please do not use this repository for new internal shared workflows and actions. Use https://github.com/Typeform/.github-private instead!

- [x] This PR only changes an existing workflow.
- [ ] This PR adds a new workflow that is needed in a public Typeform repository.
