### PR TITLE
feat(PLT-3863): add incident hotfix deploy support to frontend-deploy-workflow

### DIFF
--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -276,6 +276,12 @@ on:
         description: 'Slack channel for deployment notifications (e.g., tfprod-deploy)'
         type: string
         default: 'tfprod-deploy'
+
+      # Incident hotfix
+      incident-number:
+        description: 'Incident ticket number (e.g. INC-1234). When set, validates INC-* format and posts a war-room notification before deploying.'
+        type: string
+        default: ''
     secrets:
       GH_TOKEN:
         required: true
@@ -636,17 +642,20 @@ jobs:
       - integration-tests
       - cypress-functional
       - cypress-visual
+      - war-room-notification
     # Deploy only if:
     # - Build succeeded
     # - Each test job succeeded, OR was skipped (disabled via input OR skipped as already
     #   verified on the PR). Failure or cancellation still blocks the deploy.
+    # - War-room notification succeeded (when incident-number is set), or was skipped (normal deploy)
     if: |
       always() &&
       needs.build.result == 'success' &&
       (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&
       (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped') &&
       (needs.cypress-functional.result == 'success' || needs.cypress-functional.result == 'skipped') &&
-      (needs.cypress-visual.result == 'success' || needs.cypress-visual.result == 'skipped')
+      (needs.cypress-visual.result == 'success' || needs.cypress-visual.result == 'skipped') &&
+      (needs.war-room-notification.result == 'success' || needs.war-room-notification.result == 'skipped')
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: ${{ inputs.deploy-timeout }}
     permissions:
@@ -751,14 +760,42 @@ jobs:
           echo "📝 Commit: ${{ github.sha }}"
           echo "📋 Workflow: frontend-deploy-workflow-v2 (v2)"
   
-  # Job 9: Slack Notifications (runs after deploy completes)
+  # Job 9: War-room notification (incident hotfix deploys only)
+  war-room-notification:
+    name: 🚨 War-room notification
+    if: inputs.incident-number != ''
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Validate incident number
+        run: |
+          if [[ ! "${{ inputs.incident-number }}" =~ ^[Ii][Nn][Cc]- ]]; then
+            echo "::error::incident-number must start with 'INC-' (got: ${{ inputs.incident-number }})"
+            exit 1
+          fi
+
+      - name: Post to #war-room
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          payload: |
+            {
+              "channel": "war-room",
+              "text": "🚨🚨🚨 Deployment due to incident ${{ inputs.incident-number }} of `${{ inputs.app-name }}@${{ github.sha }}` (branch `${{ github.ref_name }}`) to production by *${{ github.actor }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|logs>) <@tech-delivery-experience>",
+              "username": "Deploy Notifier"
+            }
+
+  # Job 10: Slack Notifications (runs after deploy completes)
   notify-slack:
     name: 📢 Notify Slack
     if: always() && inputs.slack-channel != '' && needs.deploy.result != 'cancelled'
     needs: [deploy]
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    
+
     steps:
       - name: Send deployment notification
         uses: Typeform/.github/shared-actions/slack-deployment-notification@v1
@@ -772,3 +809,16 @@ jobs:
           github-server-url: ${{ github.server_url }}
           github-run-id: ${{ github.run_id }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_OAUTH_TOKEN }}
+
+      - name: Send incident result to #war-room
+        if: inputs.incident-number != ''
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          payload: |
+            {
+              "channel": "war-room",
+              "text": "${{ needs.deploy.result == 'success' && '✅' || '❌' }} Incident deployment ${{ needs.deploy.result }} — `${{ inputs.app-name }}` (${{ inputs.incident-number }}) (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|logs>)",
+              "username": "Deploy Notifier"
+            }

--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -776,7 +776,7 @@ jobs:
             exit 1
           fi
 
-      - name: Post to #war-room
+      - name: Post to war-room
         uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage

--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -770,9 +770,11 @@ jobs:
 
     steps:
       - name: Validate incident number
+        env:
+          INCIDENT_NUMBER: ${{ inputs.incident-number }}
         run: |
-          if [[ ! "${{ inputs.incident-number }}" =~ ^[Ii][Nn][Cc]- ]]; then
-            echo "::error::incident-number must start with 'INC-' (got: ${{ inputs.incident-number }})"
+          if [[ ! "$INCIDENT_NUMBER" =~ ^[Ii][Nn][Cc]-[0-9]+$ ]]; then
+            echo "::error::incident-number must match INC-<digits> (got: $INCIDENT_NUMBER)"
             exit 1
           fi
 

--- a/.github/workflows/frontend-deploy-workflow.yml
+++ b/.github/workflows/frontend-deploy-workflow.yml
@@ -810,15 +810,3 @@ jobs:
           github-run-id: ${{ github.run_id }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_OAUTH_TOKEN }}
 
-      - name: Send incident result to #war-room
-        if: inputs.incident-number != ''
-        uses: slackapi/slack-github-action@v3
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          payload: |
-            {
-              "channel": "war-room",
-              "text": "${{ needs.deploy.result == 'success' && '✅' || '❌' }} Incident deployment ${{ needs.deploy.result }} — `${{ inputs.app-name }}` (${{ inputs.incident-number }}) (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|logs>)",
-              "username": "Deploy Notifier"
-            }


### PR DESCRIPTION
# Overview

Jira ticket: https://typeform.atlassian.net/browse/PLT-3863

Adds incident hotfix deploy support to the shared `frontend-deploy-workflow`. When an app's `deploy.yml` is dispatched with an `INC-*` reason, the workflow validates the incident number, posts a 🚨 war-room notification before deploying, and reports the result to `#tfprod-deploy`.

## Changes

- Add optional `incident-number` input (default `''`)
- Add `war-room-notification` job that validates `INC-*` format and posts to `#war-room` via `slackapi/slack-github-action`
- Gate `deploy` job on `war-room-notification` succeeding or being skipped
- Normal (non-incident) deploys are completely unaffected

## Testing

To be tested end-to-end via the `Typeform/chief` PR (PLT-3863-hotfix-deploy).

## Docs

- [ ] **Yes!** :hand: I have updated the documentation.

## For contributions to the `Typeform/.github` repo

- [x] This PR only changes an existing workflow.